### PR TITLE
Subclass with 'object' #25

### DIFF
--- a/src/deltacode/__init__.py
+++ b/src/deltacode/__init__.py
@@ -33,7 +33,7 @@ from deltacode import utils
 __version__ = '0.0.1.beta'
 
 
-class DeltaCode:
+class DeltaCode(object):
     """
     Handles the basic operations on a pair of incoming ScanCode scans (in JSON
     format) and the Delta objects created from a comparison of the files (in
@@ -163,7 +163,7 @@ class DeltaCode:
         ])
 
 
-class Delta:
+class Delta(object):
     """
     A tuple reflecting a comparison of two files -- each of which is a File
     object -- and the category that characterizes the comparison:
@@ -174,10 +174,10 @@ class Delta:
         self.new_file = new_file
         self.old_file = old_file
         self.category = delta_type
-        
+
         # Change the Delta object's 'category' attribute to
         # 'license change' if a substantial license change has been detected.
-        if self.category == 'modified': 
+        if self.category == 'modified':
             self._license_diff()
 
     def _license_diff(self, cutoff_score=50):

--- a/src/deltacode/models.py
+++ b/src/deltacode/models.py
@@ -30,7 +30,7 @@ from collections import OrderedDict
 import json
 
 
-class Scan:
+class Scan(object):
     """
     Processes the files contained in an incoming ScanCode scan to test whether
     they are valid, retrieve the scan's 'files_count' value, create a list of
@@ -140,7 +140,7 @@ class Scan:
         return index
 
 
-class File:
+class File(object):
     """
     File object created from an ABCD formatted 'file' dictionary.
     """
@@ -192,7 +192,7 @@ class File:
         return "%s" % self.__dict__
 
 
-class License:
+class License(object):
     """
     License object created from the 'license' field in an ABCD formatted 'file' dictionary.
     """


### PR DESCRIPTION
  * Converted 'classic'-style classes to 'new'-style classes explicitly inheriting from `object`.

Signed-off-by: John M. Horan <johnmhoran@gmail.com>