### PR TITLE
Add info to JSON and CSV output #30

### DIFF
--- a/src/deltacode/__init__.py
+++ b/src/deltacode/__init__.py
@@ -197,25 +197,40 @@ class Delta(object):
         if self.category == 'added':
             return OrderedDict([
                 ('category', 'added'),
-                ('path', self.new_file.path)
+                ('path', self.new_file.path),
+                ('name', self.new_file.name),
+                ('type', self.new_file.type),
+                ('size', self.new_file.size)
             ])
         elif self.category == 'removed':
             return OrderedDict([
                 ('category', 'removed'),
-                ('path', self.old_file.path)
+                ('path', self.old_file.path),
+                ('name', self.old_file.name),
+                ('type', self.old_file.type),
+                ('size', self.old_file.size)
             ])
         elif self.category == 'modified':
             return OrderedDict([
                 ('category', 'modified'),
-                ('path', self.new_file.path)
+                ('path', self.new_file.path),
+                ('name', self.new_file.name),
+                ('type', self.new_file.type),
+                ('size', self.new_file.size)
             ])
         elif self.category == 'license change':
             return OrderedDict([
                 ('category', 'license change'),
-                ('path', self.new_file.path)
+                ('path', self.new_file.path),
+                ('name', self.new_file.name),
+                ('type', self.new_file.type),
+                ('size', self.new_file.size)
             ])
         else:
             return OrderedDict([
                 ('category', 'unmodified'),
-                ('path', self.new_file.path)
+                ('path', self.new_file.path),
+                ('name', self.new_file.name),
+                ('type', self.new_file.type),
+                ('size', self.new_file.size)
             ])

--- a/src/deltacode/cli.py
+++ b/src/deltacode/cli.py
@@ -43,9 +43,15 @@ def generate_csv(delta, result_file):
     """
     with open(result_file, 'wb') as out:
         csv_out = csv.writer(out)
-        csv_out.writerow(['Type of delta', 'Path'])
-        for row in [(f.category, f.old_file.path if f.category == 'removed' else f.new_file.path) for d in delta.deltas for f in delta.deltas.get(d)]:
-            csv_out.writerow(row)
+        csv_out.writerow(['Type of delta', 'Path', 'Name', 'Type', 'Size'])
+        for row in [(
+            f.category,
+            f.old_file.path if f.category == 'removed' else f.new_file.path,
+            f.old_file.name if f.category == 'removed' else f.new_file.name,
+            f.old_file.type if f.category == 'removed' else f.new_file.type,
+            f.old_file.size if f.category == 'removed' else f.new_file.size)
+                for d in delta.deltas for f in delta.deltas.get(d)]:
+                    csv_out.writerow(row)
 
 
 def generate_json(delta, result_file):

--- a/tests/data/cli/added1.csv
+++ b/tests/data/cli/added1.csv
@@ -1,10 +1,10 @@
-Type of delta,Path
-added,a/a5.py
-unmodified,a/a3.py
-unmodified,b/b4.py
-unmodified,a/a2.py
-unmodified,b/b2.py
-unmodified,b/b1.py
-unmodified,b/b3.py
-unmodified,a/a4.py
-unmodified,a/a1.py
+Type of delta,Path,Name,Type,Size
+added,a/a5.py,a5.py,file,200
+unmodified,a/a3.py,a3.py,file,200
+unmodified,b/b4.py,b4.py,file,200
+unmodified,a/a2.py,a2.py,file,200
+unmodified,b/b2.py,b2.py,file,200
+unmodified,b/b1.py,b1.py,file,200
+unmodified,b/b3.py,b3.py,file,200
+unmodified,a/a4.py,a4.py,file,200
+unmodified,a/a1.py,a1.py,file,200

--- a/tests/data/cli/modified1.csv
+++ b/tests/data/cli/modified1.csv
@@ -1,9 +1,9 @@
-Type of delta,Path
-modified,a/a4.py
-unmodified,a/a3.py
-unmodified,b/b4.py
-unmodified,b/b1.py
-unmodified,a/a2.py
-unmodified,b/b2.py
-unmodified,b/b3.py
-unmodified,a/a1.py
+Type of delta,Path,Name,Type,Size
+modified,a/a4.py,a4.py,file,246
+unmodified,a/a3.py,a3.py,file,200
+unmodified,b/b4.py,b4.py,file,200
+unmodified,b/b1.py,b1.py,file,200
+unmodified,a/a2.py,a2.py,file,200
+unmodified,b/b2.py,b2.py,file,200
+unmodified,b/b3.py,b3.py,file,200
+unmodified,a/a1.py,a1.py,file,200

--- a/tests/data/cli/modified_new_license_added.csv
+++ b/tests/data/cli/modified_new_license_added.csv
@@ -1,4 +1,4 @@
-Type of delta,Path
-modified,some/path/c/c1.py
-license change,some/path/a/a1.py
-license change,some/path/b/b1.py
+Type of delta,Path,Name,Type,Size
+modified,some/path/c/c1.py,c1.py,file,300
+license change,some/path/a/a1.py,a1.py,file,300
+license change,some/path/b/b1.py,b1.py,file,300

--- a/tests/data/cli/modified_new_license_added_low_score.csv
+++ b/tests/data/cli/modified_new_license_added_low_score.csv
@@ -1,3 +1,3 @@
-Type of delta,Path
-modified,some/path/a/a1.py
-modified,some/path/b/b1.py
+Type of delta,Path,Name,Type,Size
+modified,some/path/a/a1.py,a1.py,file,350
+modified,some/path/b/b1.py,b1.py,file,290

--- a/tests/data/cli/removed1.csv
+++ b/tests/data/cli/removed1.csv
@@ -1,9 +1,9 @@
-Type of delta,Path
-removed,a/a4.py
-unmodified,a/a3.py
-unmodified,b/b4.py
-unmodified,b/b1.py
-unmodified,a/a2.py
-unmodified,b/b2.py
-unmodified,b/b3.py
-unmodified,a/a1.py
+Type of delta,Path,Name,Type,Size
+removed,a/a4.py,a4.py,file,200
+unmodified,a/a3.py,a3.py,file,200
+unmodified,b/b4.py,b4.py,file,200
+unmodified,b/b1.py,b1.py,file,200
+unmodified,a/a2.py,a2.py,file,200
+unmodified,b/b2.py,b2.py,file,200
+unmodified,b/b3.py,b3.py,file,200
+unmodified,a/a1.py,a1.py,file,200

--- a/tests/data/cli/renamed1.csv
+++ b/tests/data/cli/renamed1.csv
@@ -1,10 +1,10 @@
-Type of delta,Path
-added,a/a4_renamed_not_modified.py
-removed,a/a4.py
-unmodified,a/a3.py
-unmodified,b/b4.py
-unmodified,b/b1.py
-unmodified,b/b2.py
-unmodified,b/b3.py
-unmodified,a/a1.py
-unmodified,a/a2.py
+Type of delta,Path,Name,Type,Size
+added,a/a4_renamed_not_modified.py,a4_renamed_not_modified.py,file,200
+removed,a/a4.py,a4.py,file,200
+unmodified,a/a3.py,a3.py,file,200
+unmodified,b/b4.py,b4.py,file,200
+unmodified,b/b1.py,b1.py,file,200
+unmodified,b/b2.py,b2.py,file,200
+unmodified,b/b3.py,b3.py,file,200
+unmodified,a/a1.py,a1.py,file,200
+unmodified,a/a2.py,a2.py,file,200

--- a/tests/test_deltacode.py
+++ b/tests/test_deltacode.py
@@ -331,7 +331,10 @@ class TestDeltacode(FileBasedTesting):
             ('unmodified', [
                 OrderedDict([
                     ('category', 'unmodified'),
-                    ('path', u'test/unmodified.txt')
+                    ('path', u'test/unmodified.txt'),
+                    ('name', u'unmodified.txt'),
+                    ('type', u'file'),
+                    ('size', 11)
                 ])
             ])
         ])
@@ -593,9 +596,13 @@ class TestDeltacode(FileBasedTesting):
             'sha1': 'a',
             'original_path': ''
         })
+
         expected = {
             'category': 'removed',
-            'path': 'path/removed.txt'
+            'path': 'path/removed.txt',
+            'name': 'removed.txt',
+            'type': 'file',
+            'size': 20
         }
 
         delta = deltacode.Delta(None, old, 'removed')
@@ -611,9 +618,13 @@ class TestDeltacode(FileBasedTesting):
             'sha1': 'a',
             'original_path': ''
         })
+
         expected = {
             'category': 'added',
-            'path': 'path/added.txt'
+            'path': 'path/added.txt',
+            'name': 'added.txt',
+            'type': 'file',
+            'size': 20
         }
 
         delta = deltacode.Delta(new, None, 'added')
@@ -640,7 +651,10 @@ class TestDeltacode(FileBasedTesting):
 
         expected = {
             'category': 'modified',
-            'path': 'path/modified.txt'
+            'path': 'path/modified.txt',
+            'name': 'modified.txt',
+            'type': 'file',
+            'size': 20
         }
 
         delta = deltacode.Delta(new, old, 'modified')
@@ -667,7 +681,10 @@ class TestDeltacode(FileBasedTesting):
 
         expected = {
             'category': 'unmodified',
-            'path': 'path/unmodified.txt'
+            'path': 'path/unmodified.txt',
+            'name': 'unmodified.txt',
+            'type': 'file',
+            'size': 20
         }
 
         delta = deltacode.Delta(new, old, 'unmodified')
@@ -677,7 +694,74 @@ class TestDeltacode(FileBasedTesting):
     def test_Delta_to_dict_empty(self):
         delta = deltacode.Delta()
 
-        assert delta.to_dict() == OrderedDict([('category', 'unmodified'), ('path', '')])
+        assert delta.to_dict() == OrderedDict([('category', 'unmodified'), ('path', ''), ('name', ''), ('type', ''), ('size', '')])
+
+    def test_Delta_to_dict_license_modified(self):
+        new_scan = self.get_test_loc('deltacode/scan_modified_new_license_added.json')
+        old_scan = self.get_test_loc('deltacode/scan_modified_old_license_added.json')
+
+        result = DeltaCode(new_scan, old_scan)
+
+        expected = OrderedDict([
+            ('added', []),
+            ('removed', []),
+            ('modified', [
+                OrderedDict([
+                    ('category', 'modified'),
+                    ('path', u'some/path/c/c1.py'),
+                    ('name', u'c1.py'),
+                    ('type', u'file'),
+                    ('size', 300)
+                ]),
+                OrderedDict([
+                    ('category', 'license change'),
+                    ('path', u'some/path/a/a1.py'),
+                    ('name', u'a1.py'),
+                    ('type', u'file'),
+                    ('size', 300)
+                ]),
+                OrderedDict([
+                    ('category', 'license change'),
+                    ('path', u'some/path/b/b1.py'),
+                    ('name', u'b1.py'),
+                    ('type', u'file'),
+                    ('size', 300)
+                ])
+            ]),
+            ('unmodified', [])
+        ])
+
+        assert result.to_dict() == expected
+
+    def test_Delta_to_dict_no_license_key_value(self):
+        new_scan = self.get_test_loc('deltacode/scan_modified_new_no_license_key.json')
+        old_scan = self.get_test_loc('deltacode/scan_modified_old_no_license_key.json')
+
+        result = DeltaCode(new_scan, old_scan)
+
+        expected = OrderedDict([
+            ('added', []),
+            ('removed', []),
+            ('modified', [
+                OrderedDict([
+                    ('category', 'modified'),
+                    ('path', u'some/path/a/a1.py'),
+                    ('name', u'a1.py'),
+                    ('type', u'file'),
+                    ('size', 250)
+                ]),
+                OrderedDict([
+                    ('category', 'modified'),
+                    ('path', u'some/path/b/b1.py'),
+                    ('name', u'b1.py'),
+                    ('type', u'file'),
+                    ('size', 310)
+                ])
+            ]),
+            ('unmodified', [])
+        ])
+
+        assert result.to_dict() == expected
 
     def test_Delta_create_object_removed(self):
         new = None


### PR DESCRIPTION
  * Refactored `Delta.to_dict()`, `generate_csv()`.
  * Output now includes `category`, `path`, `name`, `type` and `size`.
  * Fixed failing tests, added new tests.

Signed-off-by: John M. Horan <johnmhoran@gmail.com>