### PR TITLE
Modify 'deltacode_options' options keys #93

### DIFF
--- a/src/deltacode/cli.py
+++ b/src/deltacode/cli.py
@@ -69,7 +69,7 @@ def print_version(ctx, param, value):
 @click.option('-n', '--new', required=True, prompt=False, type=click.Path(exists=True, readable=True), help='Identify the path to the "new" scan file')
 @click.option('-o', '--old', required=True, prompt=False, type=click.Path(exists=True, readable=True), help='Identify the path to the "old" scan file')
 @click.option('-j', '--json-file', prompt=False, default='-', type=click.File(mode='wb', lazy=False), help='Identify the path to the .json output file')
-@click.option('-a', '--all-delta-types', is_flag=True, help="Include unmodified files as well as all changed files in the .json or .csv output.  If not selected, only changed files are included.")
+@click.option('-a', '--all-delta-types', is_flag=True, help="Include unmodified files as well as all changed files in the .json output.  If not selected, only changed files are included.")
 def cli(new, old, json_file, all_delta_types):
     """
     Identify the changes that need to be made to the 'old'
@@ -80,8 +80,8 @@ def cli(new, old, json_file, all_delta_types):
     """
     # retrieve the option selections
     options = OrderedDict([
-        ('new_scan_path', new),
-        ('old_scan_path', old),
+        ('--new', new),
+        ('--old', old),
         ('--all-delta-types', all_delta_types)
     ])
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -98,8 +98,8 @@ class TestCLI(FileBasedTesting):
         assert json_result.get('deltacode_notice') == notice
 
         options =  {
-            'new_scan_path': new_scan,
-            'old_scan_path': old_scan,
+            '--new': new_scan,
+            '--old': old_scan,
             '--all-delta-types': True
         }
 
@@ -258,8 +258,8 @@ class TestCLI(FileBasedTesting):
         assert json_result.get('deltacode_notice') == notice
 
         options =  {
-            'new_scan_path': new_scan,
-            'old_scan_path': old_scan,
+            '--new': new_scan,
+            '--old': old_scan,
             '--all-delta-types': False
         }
 


### PR DESCRIPTION
  * Also removed reference in help text to deprecated CSV output.

Signed-off-by: John M. Horan <johnmhoran@gmail.com>