### PR TITLE
Added has copyright and has license attribute to delta objects

### DIFF
--- a/etc/configure.py
+++ b/etc/configure.py
@@ -508,7 +508,6 @@ if __name__ == '__main__':
             print('ERROR: unknown option: %(arg0)s' % locals())
             print(usage)
             sys.exit(1)
-
     sys.path.insert(0, root_dir)
     bin_dir = os.path.join(root_dir, 'bin')
     standard_python = sys.executable
@@ -565,7 +564,6 @@ if __name__ == '__main__':
         create_virtualenv = create_virtualenv_py2
     else:
         create_virtualenv = create_virtualenv_py3
-
     # Finally execute our three steps: venv, install and scripts
     if not os.path.exists(configured_python):
         create_virtualenv(standard_python, root_dir, thirdparty_dirs, quiet=quiet)

--- a/src/deltacode/__init__.py
+++ b/src/deltacode/__init__.py
@@ -283,9 +283,17 @@ class Delta(object):
     def __init__(self, score=0, new_file=None, old_file=None):
         self.new_file = new_file if new_file else None
         self.old_file = old_file if old_file else None
+        self.has_license = False
+        self.has_copyright = False
         self.factors = []
         self.score = score
         self.status = ''
+    
+    def add_license(self) :
+        self.has_license = True
+
+    def add_copyright(self):
+        self.has_copyright = True    
 
     def update(self, score=0, factor=''):
         """

--- a/src/deltacode/__init__.py
+++ b/src/deltacode/__init__.py
@@ -288,12 +288,6 @@ class Delta(object):
         self.factors = []
         self.score = score
         self.status = ''
-    
-    def add_license(self) :
-        self.has_license = True
-
-    def add_copyright(self):
-        self.has_copyright = True    
 
     def update(self, score=0, factor=''):
         """

--- a/src/deltacode/utils.py
+++ b/src/deltacode/utils.py
@@ -43,10 +43,10 @@ def update_from_license_info(delta, unique_categories):
 
     if delta.new_file:
         if delta.new_file.has_licenses():
-            delta.add_license()
+            delta.has_licenses = True
     if delta.old_file:
         if delta.old_file.has_licenses():
-            delta.add_license()
+            delta.has_licenses = True
 
     if delta.is_added():
         update_added_from_license_info(delta, unique_categories)
@@ -131,10 +131,10 @@ def update_from_copyright_info(delta):
     """
     if delta.new_file:
         if delta.new_file.has_copyrights():
-            delta.add_copyright()
+            delta.has_copyrights = True
     if delta.old_file:
         if delta.old_file.has_copyrights():
-            delta.add_copyright()
+            delta.has_copyrights = True
     if delta.is_added():
         update_added_from_copyright_info(delta)
 

--- a/src/deltacode/utils.py
+++ b/src/deltacode/utils.py
@@ -40,6 +40,14 @@ def update_from_license_info(delta, unique_categories):
     one or more appropriate categories to its 'factors' attribute if there has
     been a license change and depending on the nature of that change.
     """
+
+    if delta.new_file:
+        if delta.new_file.has_licenses():
+            delta.add_license()
+    if delta.old_file:
+        if delta.old_file.has_licenses():
+            delta.add_license()
+
     if delta.is_added():
         update_added_from_license_info(delta, unique_categories)
 
@@ -121,6 +129,12 @@ def update_from_copyright_info(delta):
     one or more appropriate categories to its 'factors' attribute if there has
     been a copyright change and depending on the nature of that change.
     """
+    if delta.new_file:
+        if delta.new_file.has_copyrights():
+            delta.add_copyright()
+    if delta.old_file:
+        if delta.old_file.has_copyrights():
+            delta.add_copyright()
     if delta.is_added():
         update_added_from_copyright_info(delta)
 

--- a/tests/test_deltacode.py
+++ b/tests/test_deltacode.py
@@ -1645,7 +1645,7 @@ class TestDeltacode(FileBasedTesting):
         result_file = self.get_temp_file('json')
         args = ['--new', new_file, '--old', old_file, '--json-file', result_file, '--all-delta-types']
         test_utils.run_scan_click(args)
-        test_utils.check_json_scan(self.get_test_loc('deltacode/coala-expected-result.json'), result_file, regen=True)
+        test_utils.check_json_scan(self.get_test_loc('deltacode/coala-expected-result.json'), result_file, regen=False)
 
     def test_similarity_matching_2(self):
         old_file = self.get_test_loc('deltacode/sugar-0.108.0-old.json')
@@ -1653,7 +1653,7 @@ class TestDeltacode(FileBasedTesting):
         result_file = self.get_temp_file('json')
         args = ['--new', new_file, '--old', old_file, '--json-file', result_file, '--all-delta-types']
         test_utils.run_scan_click(args)
-        test_utils.check_json_scan(self.get_test_loc('deltacode/sugar-expected.json'), result_file, regen=True)
+        test_utils.check_json_scan(self.get_test_loc('deltacode/sugar-expected.json'), result_file, regen=False)
 
     def test_non_similarity_matching_1(self):
         old_file = self.get_test_loc('deltacode/coala-0.7.0-old.json')
@@ -1661,4 +1661,4 @@ class TestDeltacode(FileBasedTesting):
         result_file = self.get_temp_file('json')
         args = ['--new', new_file, '--old', old_file, '--json-file', result_file, '--all-delta-types']
         test_utils.run_scan_click(args)
-        test_utils.check_json_scan(self.get_test_loc('deltacode/sugar-coala-expected.json'), result_file, regen=True)
+        test_utils.check_json_scan(self.get_test_loc('deltacode/sugar-coala-expected.json'), result_file, regen=False)


### PR DESCRIPTION
In this PR I added a the option to add the attribute has_license and has_copyright to the delta objects.
When either of the new file of the old file has a copyright or an license this attributes will be set to true,by default it is False
`
class Delta(object):
    """
    A tuple reflecting a comparison of two files -- each of which is a File
    object -- and the 'factors' (e.g., 'added', 'modified' etc.) and related
    'score' that characterize that comparison.
    """
    def __init__(self, score=0, new_file=None, old_file=None):
        self.new_file = new_file if new_file else None
        self.old_file = old_file if old_file else None
        self.has_license = False
        self.has_copyright = False
        self.factors = []
        self.score = score
        self.status = ''
    
    def add_license(self) :
        self.has_license = True

    def add_copyright(self):
        self.has_copyright = True    

`

This PR is meant to solve issue of #109 