### PR TITLE
changed dict to OrderedDict so as to align the scans in correct order.

### DIFF
--- a/src/deltacode/models.py
+++ b/src/deltacode/models.py
@@ -155,7 +155,7 @@ class Scan(object):
         keyed by the File object's 'path' variable.  This function does not
         currently catch the AttributeError exception.
         """
-        index = {}
+        index = OrderedDict()
 
         for f in self.files:
             key = getattr(f, index_key)

--- a/tests/data/deltacode/coala-expected-result.json
+++ b/tests/data/deltacode/coala-expected-result.json
@@ -17,13 +17,13 @@
       "factors": [],
       "score": 100,
       "new": {
-        "path": "coalib/testing/LocalBearTestHelper.py",
+        "path": "coalib/coala_modes.py",
         "type": "file",
-        "name": "LocalBearTestHelper.py",
-        "size": 9119,
-        "sha1": "f7cc9efd05776b92a048505af1742b173fff276d",
-        "fingerprint": "0b6d8e58410aa6f9b25e60ee66e6ffb3",
-        "original_path": "coalib/testing/LocalBearTestHelper.py",
+        "name": "coala_modes.py",
+        "size": 3383,
+        "sha1": "b787b12e95d46676df02b5a0d7ae740db8631c39",
+        "fingerprint": "e8e5e4a5c8873621333c8bc4d8f52d70",
+        "original_path": "coalib/coala_modes.py",
         "licenses": [],
         "copyrights": []
       },
@@ -34,13 +34,13 @@
       "factors": [],
       "score": 100,
       "new": {
-        "path": "coalib/bearlib/languages/definitions/C.py",
+        "path": "coalib/bearlib/aspects/__init__.py",
         "type": "file",
-        "name": "C.py",
-        "size": 854,
-        "sha1": "0dc5ebcdde66051b9faa81cf0276ed27606f0af3",
-        "fingerprint": "8b87b1284ee299efc75b516b956ec8d9",
-        "original_path": "coalib/bearlib/languages/definitions/C.py",
+        "name": "__init__.py",
+        "size": 3402,
+        "sha1": "0c7bd34da16043fc8213a78e3e1ce52d6cc56caa",
+        "fingerprint": "1f35f6b654088409c60432ef061586a0",
+        "original_path": "coalib/bearlib/aspects/__init__.py",
         "licenses": [],
         "copyrights": []
       },
@@ -51,47 +51,13 @@
       "factors": [],
       "score": 100,
       "new": {
-        "path": "coalib/bearlib/languages/definitions/Vala.py",
+        "path": "coalib/bearlib/aspects/base.py",
         "type": "file",
-        "name": "Vala.py",
-        "size": 345,
-        "sha1": "ffc71a5704f96d7762e830cf8f45efa5a99b9b30",
-        "fingerprint": "980fc93c6643e860828241a9b54678c0",
-        "original_path": "coalib/bearlib/languages/definitions/Vala.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "coalib/bearlib/languages/definitions/CSS.py",
-        "type": "file",
-        "name": "CSS.py",
-        "size": 304,
-        "sha1": "d1b42eb998a77c50ee99c520ee3d8d51763c86ab",
-        "fingerprint": "9b8aca31be42bf589fc749a3854f700d",
-        "original_path": "coalib/bearlib/languages/definitions/CSS.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "coalib/output/ConsoleInteraction.py",
-        "type": "file",
-        "name": "ConsoleInteraction.py",
-        "size": 32748,
-        "sha1": "32988a3281d1a91677bc145fc03db80c1ef62dc8",
-        "fingerprint": "8a607554abc1cb9c495354f5c9982d11",
-        "original_path": "coalib/output/ConsoleInteraction.py",
+        "name": "base.py",
+        "size": 2106,
+        "sha1": "8414faf1f7bc07d2dd73bef8e84d37d35e069604",
+        "fingerprint": "e8e295866ae7640e23bdb9c87f647fa9",
+        "original_path": "coalib/bearlib/aspects/base.py",
         "licenses": [],
         "copyrights": []
       },
@@ -119,115 +85,13 @@
       "factors": [],
       "score": 100,
       "new": {
-        "path": "coalib/coala_modes.py",
+        "path": "coalib/bearlib/aspects/meta.py",
         "type": "file",
-        "name": "coala_modes.py",
-        "size": 3383,
-        "sha1": "b787b12e95d46676df02b5a0d7ae740db8631c39",
-        "fingerprint": "e8e5e4a5c8873621333c8bc4d8f52d70",
-        "original_path": "coalib/coala_modes.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "coalib/results/result_actions/IgnoreResultAction.py",
-        "type": "file",
-        "name": "IgnoreResultAction.py",
-        "size": 4109,
-        "sha1": "b81b6ef019de45edc91a029c6ff65c4e0be8ac5c",
-        "fingerprint": "e72aa3e97698ed2562d12c65ee1c1182",
-        "original_path": "coalib/results/result_actions/IgnoreResultAction.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "coalib/bearlib/languages/definitions/Unknown.py",
-        "type": "file",
-        "name": "Unknown.py",
-        "size": 91,
-        "sha1": "bba9c1d0ba06944fd744a8b21c1f886278b2bcb4",
-        "fingerprint": "2e538a180c2a43e272605142c5463048",
-        "original_path": "coalib/bearlib/languages/definitions/Unknown.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "coalib/results/result_actions/PrintAspectAction.py",
-        "type": "file",
-        "name": "PrintAspectAction.py",
-        "size": 704,
-        "sha1": "5807c6417acd936e207c4eb6a07a61a9b9338930",
-        "fingerprint": "755a2fcf9c448a802ef46009ba9c6846",
-        "original_path": "coalib/results/result_actions/PrintAspectAction.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "coalib/bearlib/languages/definitions/Java.py",
-        "type": "file",
-        "name": "Java.py",
-        "size": 325,
-        "sha1": "c5d25b7336a141c16d50dafedfbc5edd51a2f53b",
-        "fingerprint": "0a03c93c3e420ce897699029954e90e3",
-        "original_path": "coalib/bearlib/languages/definitions/Java.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "coalib/bearlib/languages/definitions/JavaScript.py",
-        "type": "file",
-        "name": "JavaScript.py",
-        "size": 372,
-        "sha1": "e02eef3e90b166486c99ee3d465e0f7d09635164",
-        "fingerprint": "8702c97436629cc896e1c1a9954e7c22",
-        "original_path": "coalib/bearlib/languages/definitions/JavaScript.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "coalib/bearlib/aspects/base.py",
-        "type": "file",
-        "name": "base.py",
-        "size": 2106,
-        "sha1": "8414faf1f7bc07d2dd73bef8e84d37d35e069604",
-        "fingerprint": "e8e295866ae7640e23bdb9c87f647fa9",
-        "original_path": "coalib/bearlib/aspects/base.py",
+        "name": "meta.py",
+        "size": 2121,
+        "sha1": "13c6ea613e56cdd0141fd91b99ba1371e7ed0ff0",
+        "fingerprint": "932d49723eb293bdb1f1f789d8cef62e",
+        "original_path": "coalib/bearlib/aspects/meta.py",
         "licenses": [],
         "copyrights": []
       },
@@ -272,6 +136,23 @@
       "factors": [],
       "score": 100,
       "new": {
+        "path": "coalib/bearlib/aspects/taste.py",
+        "type": "file",
+        "name": "taste.py",
+        "size": 2896,
+        "sha1": "68ad8f8efb4a57cd48c279f3f5d58948212cb1aa",
+        "fingerprint": "1fe3af3b2c9452658904f0767ebf5761",
+        "original_path": "coalib/bearlib/aspects/taste.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
         "path": "coalib/bearlib/languages/Language.py",
         "type": "file",
         "name": "Language.py",
@@ -289,64 +170,13 @@
       "factors": [],
       "score": 100,
       "new": {
-        "path": "coalib/bearlib/languages/definitions/Python.py",
+        "path": "coalib/bearlib/languages/definitions/C.py",
         "type": "file",
-        "name": "Python.py",
-        "size": 414,
-        "sha1": "aac5bfe4aa4d2d8c6d8d4b37483c649e1cb60a92",
-        "fingerprint": "e8084b5abc4647568cbf49bb0deb7a28",
-        "original_path": "coalib/bearlib/languages/definitions/Python.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "coalib/testing/BearTestHelper.py",
-        "type": "file",
-        "name": "BearTestHelper.py",
-        "size": 513,
-        "sha1": "ce929e54914605a8cb2c58c87235f8911d09d133",
-        "fingerprint": "3299c7c84ad4d0de3ea4617aa0e69ada",
-        "original_path": "coalib/testing/BearTestHelper.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "coalib/settings/Annotations.py",
-        "type": "file",
-        "name": "Annotations.py",
-        "size": 1580,
-        "sha1": "869f6eb810c52fb8a48a1d9f538ed379c42658f4",
-        "fingerprint": "b08707e21cfa0145500072973873e10c",
-        "original_path": "coalib/settings/Annotations.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "coalib/bearlib/languages/definitions/CSharp.py",
-        "type": "file",
-        "name": "CSharp.py",
-        "size": 261,
-        "sha1": "2303b6be2926902fce6e136af99557c30e02a886",
-        "fingerprint": "84d399bd3c4249e18722600b9141009a",
-        "original_path": "coalib/bearlib/languages/definitions/CSharp.py",
+        "name": "C.py",
+        "size": 854,
+        "sha1": "0dc5ebcdde66051b9faa81cf0276ed27606f0af3",
+        "fingerprint": "8b87b1284ee299efc75b516b956ec8d9",
+        "original_path": "coalib/bearlib/languages/definitions/C.py",
         "licenses": [],
         "copyrights": []
       },
@@ -374,13 +204,115 @@
       "factors": [],
       "score": 100,
       "new": {
-        "path": "coalib/bearlib/aspects/__init__.py",
+        "path": "coalib/bearlib/languages/definitions/CSharp.py",
         "type": "file",
-        "name": "__init__.py",
-        "size": 3402,
-        "sha1": "0c7bd34da16043fc8213a78e3e1ce52d6cc56caa",
-        "fingerprint": "1f35f6b654088409c60432ef061586a0",
-        "original_path": "coalib/bearlib/aspects/__init__.py",
+        "name": "CSharp.py",
+        "size": 261,
+        "sha1": "2303b6be2926902fce6e136af99557c30e02a886",
+        "fingerprint": "84d399bd3c4249e18722600b9141009a",
+        "original_path": "coalib/bearlib/languages/definitions/CSharp.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "coalib/bearlib/languages/definitions/CSS.py",
+        "type": "file",
+        "name": "CSS.py",
+        "size": 304,
+        "sha1": "d1b42eb998a77c50ee99c520ee3d8d51763c86ab",
+        "fingerprint": "9b8aca31be42bf589fc749a3854f700d",
+        "original_path": "coalib/bearlib/languages/definitions/CSS.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "coalib/bearlib/languages/definitions/Java.py",
+        "type": "file",
+        "name": "Java.py",
+        "size": 325,
+        "sha1": "c5d25b7336a141c16d50dafedfbc5edd51a2f53b",
+        "fingerprint": "0a03c93c3e420ce897699029954e90e3",
+        "original_path": "coalib/bearlib/languages/definitions/Java.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "coalib/bearlib/languages/definitions/JavaScript.py",
+        "type": "file",
+        "name": "JavaScript.py",
+        "size": 372,
+        "sha1": "e02eef3e90b166486c99ee3d465e0f7d09635164",
+        "fingerprint": "8702c97436629cc896e1c1a9954e7c22",
+        "original_path": "coalib/bearlib/languages/definitions/JavaScript.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "coalib/bearlib/languages/definitions/Python.py",
+        "type": "file",
+        "name": "Python.py",
+        "size": 414,
+        "sha1": "aac5bfe4aa4d2d8c6d8d4b37483c649e1cb60a92",
+        "fingerprint": "e8084b5abc4647568cbf49bb0deb7a28",
+        "original_path": "coalib/bearlib/languages/definitions/Python.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "coalib/bearlib/languages/definitions/Unknown.py",
+        "type": "file",
+        "name": "Unknown.py",
+        "size": 91,
+        "sha1": "bba9c1d0ba06944fd744a8b21c1f886278b2bcb4",
+        "fingerprint": "2e538a180c2a43e272605142c5463048",
+        "original_path": "coalib/bearlib/languages/definitions/Unknown.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "coalib/bearlib/languages/definitions/Vala.py",
+        "type": "file",
+        "name": "Vala.py",
+        "size": 345,
+        "sha1": "ffc71a5704f96d7762e830cf8f45efa5a99b9b30",
+        "fingerprint": "980fc93c6643e860828241a9b54678c0",
+        "original_path": "coalib/bearlib/languages/definitions/Vala.py",
         "licenses": [],
         "copyrights": []
       },
@@ -408,6 +340,23 @@
       "factors": [],
       "score": 100,
       "new": {
+        "path": "coalib/output/ConsoleInteraction.py",
+        "type": "file",
+        "name": "ConsoleInteraction.py",
+        "size": 32748,
+        "sha1": "32988a3281d1a91677bc145fc03db80c1ef62dc8",
+        "fingerprint": "8a607554abc1cb9c495354f5c9982d11",
+        "original_path": "coalib/output/ConsoleInteraction.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
         "path": "coalib/output/Logging.py",
         "type": "file",
         "name": "Logging.py",
@@ -425,13 +374,13 @@
       "factors": [],
       "score": 100,
       "new": {
-        "path": "coalib/bearlib/aspects/meta.py",
+        "path": "coalib/results/result_actions/IgnoreResultAction.py",
         "type": "file",
-        "name": "meta.py",
-        "size": 2121,
-        "sha1": "13c6ea613e56cdd0141fd91b99ba1371e7ed0ff0",
-        "fingerprint": "932d49723eb293bdb1f1f789d8cef62e",
-        "original_path": "coalib/bearlib/aspects/meta.py",
+        "name": "IgnoreResultAction.py",
+        "size": 4109,
+        "sha1": "b81b6ef019de45edc91a029c6ff65c4e0be8ac5c",
+        "fingerprint": "e72aa3e97698ed2562d12c65ee1c1182",
+        "original_path": "coalib/results/result_actions/IgnoreResultAction.py",
         "licenses": [],
         "copyrights": []
       },
@@ -442,13 +391,64 @@
       "factors": [],
       "score": 100,
       "new": {
-        "path": "coalib/bearlib/aspects/taste.py",
+        "path": "coalib/results/result_actions/PrintAspectAction.py",
         "type": "file",
-        "name": "taste.py",
-        "size": 2896,
-        "sha1": "68ad8f8efb4a57cd48c279f3f5d58948212cb1aa",
-        "fingerprint": "1fe3af3b2c9452658904f0767ebf5761",
-        "original_path": "coalib/bearlib/aspects/taste.py",
+        "name": "PrintAspectAction.py",
+        "size": 704,
+        "sha1": "5807c6417acd936e207c4eb6a07a61a9b9338930",
+        "fingerprint": "755a2fcf9c448a802ef46009ba9c6846",
+        "original_path": "coalib/results/result_actions/PrintAspectAction.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "coalib/settings/Annotations.py",
+        "type": "file",
+        "name": "Annotations.py",
+        "size": 1580,
+        "sha1": "869f6eb810c52fb8a48a1d9f538ed379c42658f4",
+        "fingerprint": "b08707e21cfa0145500072973873e10c",
+        "original_path": "coalib/settings/Annotations.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "coalib/testing/BearTestHelper.py",
+        "type": "file",
+        "name": "BearTestHelper.py",
+        "size": 513,
+        "sha1": "ce929e54914605a8cb2c58c87235f8911d09d133",
+        "fingerprint": "3299c7c84ad4d0de3ea4617aa0e69ada",
+        "original_path": "coalib/testing/BearTestHelper.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "coalib/testing/LocalBearTestHelper.py",
+        "type": "file",
+        "name": "LocalBearTestHelper.py",
+        "size": 9119,
+        "sha1": "f7cc9efd05776b92a048505af1742b173fff276d",
+        "fingerprint": "0b6d8e58410aa6f9b25e60ee66e6ffb3",
+        "original_path": "coalib/testing/LocalBearTestHelper.py",
         "licenses": [],
         "copyrights": []
       },
@@ -606,35 +606,6 @@
       ],
       "score": 53,
       "new": {
-        "path": "coalib/parsing/ConfParser.py",
-        "type": "file",
-        "name": "ConfParser.py",
-        "size": 5180,
-        "sha1": "e83ec0ecd4fc1896d134474241d7ee2cc4be4479",
-        "fingerprint": "3fa622b4eecb9d7ce349206eb4c84e3e",
-        "original_path": "coalib/parsing/ConfParser.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "coalib/parsing/ConfParser.py",
-        "type": "file",
-        "name": "ConfParser.py",
-        "size": 4972,
-        "sha1": "1d22cefa6947824fd1de7ebb24afc2e619b3a4e6",
-        "fingerprint": "2fb6e0b4edcbc8e4ab45ab6e88e8689c",
-        "original_path": "coalib/parsing/ConfParser.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 33"
-      ],
-      "score": 53,
-      "new": {
         "path": "coalib/output/printers/LogPrinter.py",
         "type": "file",
         "name": "LogPrinter.py",
@@ -660,28 +631,28 @@
     {
       "status": "modified",
       "factors": [
-        "Similar with hamming distance : 32"
+        "Similar with hamming distance : 33"
       ],
-      "score": 52,
+      "score": 53,
       "new": {
-        "path": "coalib/settings/DocstringMetadata.py",
+        "path": "coalib/parsing/ConfParser.py",
         "type": "file",
-        "name": "DocstringMetadata.py",
-        "size": 2505,
-        "sha1": "fd4d527fdea74a82be5010426b224483226355ee",
-        "fingerprint": "48b8eef0742d6a76e291127fc1d55f78",
-        "original_path": "coalib/settings/DocstringMetadata.py",
+        "name": "ConfParser.py",
+        "size": 5180,
+        "sha1": "e83ec0ecd4fc1896d134474241d7ee2cc4be4479",
+        "fingerprint": "3fa622b4eecb9d7ce349206eb4c84e3e",
+        "original_path": "coalib/parsing/ConfParser.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "coalib/settings/DocstringMetadata.py",
+        "path": "coalib/parsing/ConfParser.py",
         "type": "file",
-        "name": "DocstringMetadata.py",
-        "size": 2495,
-        "sha1": "027f523e4098610452e54bf6c3f96610f0aec7cf",
-        "fingerprint": "48b8eaa17445cb47e1d89a77cddaf97a",
-        "original_path": "coalib/settings/DocstringMetadata.py",
+        "name": "ConfParser.py",
+        "size": 4972,
+        "sha1": "1d22cefa6947824fd1de7ebb24afc2e619b3a4e6",
+        "fingerprint": "2fb6e0b4edcbc8e4ab45ab6e88e8689c",
+        "original_path": "coalib/parsing/ConfParser.py",
         "licenses": [],
         "copyrights": []
       }
@@ -718,28 +689,28 @@
     {
       "status": "modified",
       "factors": [
-        "Similar with hamming distance : 31"
+        "Similar with hamming distance : 32"
       ],
-      "score": 51,
+      "score": 52,
       "new": {
-        "path": "coalib/coala_main.py",
+        "path": "coalib/settings/DocstringMetadata.py",
         "type": "file",
-        "name": "coala_main.py",
-        "size": 5853,
-        "sha1": "8186eca0f29f233cff0c08c6103a5a705c7bcc66",
-        "fingerprint": "48fd5496068e35099de761903335a4e9",
-        "original_path": "coalib/coala_main.py",
+        "name": "DocstringMetadata.py",
+        "size": 2505,
+        "sha1": "fd4d527fdea74a82be5010426b224483226355ee",
+        "fingerprint": "48b8eef0742d6a76e291127fc1d55f78",
+        "original_path": "coalib/settings/DocstringMetadata.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "coalib/coala_main.py",
+        "path": "coalib/settings/DocstringMetadata.py",
         "type": "file",
-        "name": "coala_main.py",
-        "size": 5013,
-        "sha1": "1d92b5257fded9b408a579c0fc13d83f0c455c86",
-        "fingerprint": "78f4dc871b1e370185e021193b3734cd",
-        "original_path": "coalib/coala_main.py",
+        "name": "DocstringMetadata.py",
+        "size": 2495,
+        "sha1": "027f523e4098610452e54bf6c3f96610f0aec7cf",
+        "fingerprint": "48b8eaa17445cb47e1d89a77cddaf97a",
+        "original_path": "coalib/settings/DocstringMetadata.py",
         "licenses": [],
         "copyrights": []
       }
@@ -769,6 +740,35 @@
         "sha1": "ba470220cfe23896e03e01094899e6fe94e37a3a",
         "fingerprint": "d98322005edec725659f7ca9b42aab2c",
         "original_path": "coalib/coala_delete_orig.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 31"
+      ],
+      "score": 51,
+      "new": {
+        "path": "coalib/coala_main.py",
+        "type": "file",
+        "name": "coala_main.py",
+        "size": 5853,
+        "sha1": "8186eca0f29f233cff0c08c6103a5a705c7bcc66",
+        "fingerprint": "48fd5496068e35099de761903335a4e9",
+        "original_path": "coalib/coala_main.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "coalib/coala_main.py",
+        "type": "file",
+        "name": "coala_main.py",
+        "size": 5013,
+        "sha1": "1d92b5257fded9b408a579c0fc13d83f0c455c86",
+        "fingerprint": "78f4dc871b1e370185e021193b3734cd",
+        "original_path": "coalib/coala_main.py",
         "licenses": [],
         "copyrights": []
       }
@@ -896,6 +896,35 @@
       ],
       "score": 46,
       "new": {
+        "path": "coalib/bearlib/abstractions/ExternalBearWrap.py",
+        "type": "file",
+        "name": "ExternalBearWrap.py",
+        "size": 7569,
+        "sha1": "b14944627d01b77995987e177ef5684ed2c93b75",
+        "fingerprint": "b1e971936b1949420d2a62d485afd074",
+        "original_path": "coalib/bearlib/abstractions/ExternalBearWrap.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "coalib/bearlib/abstractions/ExternalBearWrap.py",
+        "type": "file",
+        "name": "ExternalBearWrap.py",
+        "size": 7867,
+        "sha1": "161505af88d7b664904da509f91ac9ac2b3cd742",
+        "fingerprint": "b8c47183ea595f200dab02d485b6d16c",
+        "original_path": "coalib/bearlib/abstractions/ExternalBearWrap.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 26"
+      ],
+      "score": 46,
+      "new": {
         "path": "coalib/bears/BEAR_KIND.py",
         "type": "file",
         "name": "BEAR_KIND.py",
@@ -943,35 +972,6 @@
         "sha1": "48b2fcf56ef62729ff1a673f81705a0b44ea22da",
         "fingerprint": "cf414f759c8dcb87bedc697fc73d00ea",
         "original_path": "coalib/results/TextRange.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 26"
-      ],
-      "score": 46,
-      "new": {
-        "path": "coalib/bearlib/abstractions/ExternalBearWrap.py",
-        "type": "file",
-        "name": "ExternalBearWrap.py",
-        "size": 7569,
-        "sha1": "b14944627d01b77995987e177ef5684ed2c93b75",
-        "fingerprint": "b1e971936b1949420d2a62d485afd074",
-        "original_path": "coalib/bearlib/abstractions/ExternalBearWrap.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "coalib/bearlib/abstractions/ExternalBearWrap.py",
-        "type": "file",
-        "name": "ExternalBearWrap.py",
-        "size": 7867,
-        "sha1": "161505af88d7b664904da509f91ac9ac2b3cd742",
-        "fingerprint": "b8c47183ea595f200dab02d485b6d16c",
-        "original_path": "coalib/bearlib/abstractions/ExternalBearWrap.py",
         "licenses": [],
         "copyrights": []
       }
@@ -1070,64 +1070,6 @@
       ],
       "score": 43,
       "new": {
-        "path": "coalib/parsing/CliParsing.py",
-        "type": "file",
-        "name": "CliParsing.py",
-        "size": 4729,
-        "sha1": "ce40b47aefae0e4ebd80e8fe2789d801d641b12e",
-        "fingerprint": "0bcd4d95139f55044829eba88223cdca",
-        "original_path": "coalib/parsing/CliParsing.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "coalib/parsing/CliParsing.py",
-        "type": "file",
-        "name": "CliParsing.py",
-        "size": 4608,
-        "sha1": "ac872955d8f7077981dd9ffb0a862dde77b6a105",
-        "fingerprint": "2bcd40951316352148196b2a8a63499a",
-        "original_path": "coalib/parsing/CliParsing.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 23"
-      ],
-      "score": 43,
-      "new": {
-        "path": "coalib/output/printers/ListLogPrinter.py",
-        "type": "file",
-        "name": "ListLogPrinter.py",
-        "size": 978,
-        "sha1": "f7dbe1e9ae4344f863c60f436ff4268dd0125fb8",
-        "fingerprint": "9a49bb5c8eaf385305670bb6229628ed",
-        "original_path": "coalib/output/printers/ListLogPrinter.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "coalib/output/printers/ListLogPrinter.py",
-        "type": "file",
-        "name": "ListLogPrinter.py",
-        "size": 1002,
-        "sha1": "1e041b0f70a6611482b8cc87729a454360f6c5a5",
-        "fingerprint": "1849b95ccea730fb04c10a92a28638a1",
-        "original_path": "coalib/output/printers/ListLogPrinter.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 23"
-      ],
-      "score": 43,
-      "new": {
         "path": "coalib/collecting/Collectors.py",
         "type": "file",
         "name": "Collectors.py",
@@ -1175,6 +1117,64 @@
         "sha1": "9bdba7e9b025e12ae4a7c632772623fe26d61c28",
         "fingerprint": "b82f9a96d5e755f9444ce739a5c54150",
         "original_path": "coalib/misc/Exceptions.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 23"
+      ],
+      "score": 43,
+      "new": {
+        "path": "coalib/output/printers/ListLogPrinter.py",
+        "type": "file",
+        "name": "ListLogPrinter.py",
+        "size": 978,
+        "sha1": "f7dbe1e9ae4344f863c60f436ff4268dd0125fb8",
+        "fingerprint": "9a49bb5c8eaf385305670bb6229628ed",
+        "original_path": "coalib/output/printers/ListLogPrinter.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "coalib/output/printers/ListLogPrinter.py",
+        "type": "file",
+        "name": "ListLogPrinter.py",
+        "size": 1002,
+        "sha1": "1e041b0f70a6611482b8cc87729a454360f6c5a5",
+        "fingerprint": "1849b95ccea730fb04c10a92a28638a1",
+        "original_path": "coalib/output/printers/ListLogPrinter.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 23"
+      ],
+      "score": 43,
+      "new": {
+        "path": "coalib/parsing/CliParsing.py",
+        "type": "file",
+        "name": "CliParsing.py",
+        "size": 4729,
+        "sha1": "ce40b47aefae0e4ebd80e8fe2789d801d641b12e",
+        "fingerprint": "0bcd4d95139f55044829eba88223cdca",
+        "original_path": "coalib/parsing/CliParsing.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "coalib/parsing/CliParsing.py",
+        "type": "file",
+        "name": "CliParsing.py",
+        "size": 4608,
+        "sha1": "ac872955d8f7077981dd9ffb0a862dde77b6a105",
+        "fingerprint": "2bcd40951316352148196b2a8a63499a",
+        "original_path": "coalib/parsing/CliParsing.py",
         "licenses": [],
         "copyrights": []
       }
@@ -1273,35 +1273,6 @@
       ],
       "score": 38,
       "new": {
-        "path": "coalib/results/SourcePosition.py",
-        "type": "file",
-        "name": "SourcePosition.py",
-        "size": 1282,
-        "sha1": "b60c1e92c53dafb8ee25b90fdf5633f53cc7faed",
-        "fingerprint": "554e4b415548a8ecbdc566edac9573a4",
-        "original_path": "coalib/results/SourcePosition.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "coalib/results/SourcePosition.py",
-        "type": "file",
-        "name": "SourcePosition.py",
-        "size": 1287,
-        "sha1": "fa17682d4e15e32e3f1b72c21e9232f9fb35a2f7",
-        "fingerprint": "15484bc17569a8ed9cc166afee8773b4",
-        "original_path": "coalib/results/SourcePosition.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 18"
-      ],
-      "score": 38,
-      "new": {
         "path": "coalib/results/HiddenResult.py",
         "type": "file",
         "name": "HiddenResult.py",
@@ -1320,6 +1291,35 @@
         "sha1": "6e345fb1ba8824d211f5cf6de9bf92dd9477a721",
         "fingerprint": "b91b4a4702a7a803f9696ee71735e82e",
         "original_path": "coalib/results/HiddenResult.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 18"
+      ],
+      "score": 38,
+      "new": {
+        "path": "coalib/results/SourcePosition.py",
+        "type": "file",
+        "name": "SourcePosition.py",
+        "size": 1282,
+        "sha1": "b60c1e92c53dafb8ee25b90fdf5633f53cc7faed",
+        "fingerprint": "554e4b415548a8ecbdc566edac9573a4",
+        "original_path": "coalib/results/SourcePosition.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "coalib/results/SourcePosition.py",
+        "type": "file",
+        "name": "SourcePosition.py",
+        "size": 1287,
+        "sha1": "fa17682d4e15e32e3f1b72c21e9232f9fb35a2f7",
+        "fingerprint": "15484bc17569a8ed9cc166afee8773b4",
+        "original_path": "coalib/results/SourcePosition.py",
         "licenses": [],
         "copyrights": []
       }
@@ -1360,24 +1360,24 @@
       ],
       "score": 35,
       "new": {
-        "path": "coalib/settings/FunctionMetadata.py",
+        "path": "coalib/misc/CachingUtilities.py",
         "type": "file",
-        "name": "FunctionMetadata.py",
-        "size": 11704,
-        "sha1": "a9f22a93041e9077239e688b4653d854631be102",
-        "fingerprint": "5030282c321ff31dbf0a4993dbb674a6",
-        "original_path": "coalib/settings/FunctionMetadata.py",
+        "name": "CachingUtilities.py",
+        "size": 7156,
+        "sha1": "eee3465fcf43bdcc933d0a5538753fca85e133c7",
+        "fingerprint": "7ae9987022de6558fc3c7180e86b7ebc",
+        "original_path": "coalib/misc/CachingUtilities.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "coalib/settings/FunctionMetadata.py",
+        "path": "coalib/misc/CachingUtilities.py",
         "type": "file",
-        "name": "FunctionMetadata.py",
-        "size": 10507,
-        "sha1": "f4da0dce54826c68cb3241e27b09d4478abf23d1",
-        "fingerprint": "7060282c309df21dbf024d9387b674af",
-        "original_path": "coalib/settings/FunctionMetadata.py",
+        "name": "CachingUtilities.py",
+        "size": 6502,
+        "sha1": "81c78d59bff4c19ad188183530ebd3758b247d40",
+        "fingerprint": "7ac5987404de6c98ecbc7180e8633ebc",
+        "original_path": "coalib/misc/CachingUtilities.py",
         "licenses": [],
         "copyrights": []
       }
@@ -1418,35 +1418,6 @@
       ],
       "score": 35,
       "new": {
-        "path": "coalib/settings/ConfigurationGathering.py",
-        "type": "file",
-        "name": "ConfigurationGathering.py",
-        "size": 14106,
-        "sha1": "9863a6d4e0203256a8f3a0b0499003ca7f9b93ba",
-        "fingerprint": "3b28b414c0cfe335857b718b0ad5f1cd",
-        "original_path": "coalib/settings/ConfigurationGathering.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "coalib/settings/ConfigurationGathering.py",
-        "type": "file",
-        "name": "ConfigurationGathering.py",
-        "size": 12826,
-        "sha1": "d7ad37ad4817fdeda51adaab56fdb5b30398caaa",
-        "fingerprint": "1b28a404cb47a335877b71cf0ad4e9cd",
-        "original_path": "coalib/settings/ConfigurationGathering.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 15"
-      ],
-      "score": 35,
-      "new": {
         "path": "coalib/results/TextPosition.py",
         "type": "file",
         "name": "TextPosition.py",
@@ -1476,24 +1447,53 @@
       ],
       "score": 35,
       "new": {
-        "path": "coalib/misc/CachingUtilities.py",
+        "path": "coalib/settings/ConfigurationGathering.py",
         "type": "file",
-        "name": "CachingUtilities.py",
-        "size": 7156,
-        "sha1": "eee3465fcf43bdcc933d0a5538753fca85e133c7",
-        "fingerprint": "7ae9987022de6558fc3c7180e86b7ebc",
-        "original_path": "coalib/misc/CachingUtilities.py",
+        "name": "ConfigurationGathering.py",
+        "size": 14106,
+        "sha1": "9863a6d4e0203256a8f3a0b0499003ca7f9b93ba",
+        "fingerprint": "3b28b414c0cfe335857b718b0ad5f1cd",
+        "original_path": "coalib/settings/ConfigurationGathering.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "coalib/misc/CachingUtilities.py",
+        "path": "coalib/settings/ConfigurationGathering.py",
         "type": "file",
-        "name": "CachingUtilities.py",
-        "size": 6502,
-        "sha1": "81c78d59bff4c19ad188183530ebd3758b247d40",
-        "fingerprint": "7ac5987404de6c98ecbc7180e8633ebc",
-        "original_path": "coalib/misc/CachingUtilities.py",
+        "name": "ConfigurationGathering.py",
+        "size": 12826,
+        "sha1": "d7ad37ad4817fdeda51adaab56fdb5b30398caaa",
+        "fingerprint": "1b28a404cb47a335877b71cf0ad4e9cd",
+        "original_path": "coalib/settings/ConfigurationGathering.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 15"
+      ],
+      "score": 35,
+      "new": {
+        "path": "coalib/settings/FunctionMetadata.py",
+        "type": "file",
+        "name": "FunctionMetadata.py",
+        "size": 11704,
+        "sha1": "a9f22a93041e9077239e688b4653d854631be102",
+        "fingerprint": "5030282c321ff31dbf0a4993dbb674a6",
+        "original_path": "coalib/settings/FunctionMetadata.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "coalib/settings/FunctionMetadata.py",
+        "type": "file",
+        "name": "FunctionMetadata.py",
+        "size": 10507,
+        "sha1": "f4da0dce54826c68cb3241e27b09d4478abf23d1",
+        "fingerprint": "7060282c309df21dbf024d9387b674af",
+        "original_path": "coalib/settings/FunctionMetadata.py",
         "licenses": [],
         "copyrights": []
       }
@@ -1505,53 +1505,24 @@
       ],
       "score": 34,
       "new": {
-        "path": "coalib/settings/SectionFilling.py",
+        "path": "coalib/bears/LocalBear.py",
         "type": "file",
-        "name": "SectionFilling.py",
-        "size": 3855,
-        "sha1": "406a05444557923c22a51d98845ec747c331fb3b",
-        "fingerprint": "b15e32979b2434b587c04382173795ea",
-        "original_path": "coalib/settings/SectionFilling.py",
+        "name": "LocalBear.py",
+        "size": 1522,
+        "sha1": "74c46b4dff0a0bfaddae3945bf3e247544032160",
+        "fingerprint": "526ef2ed89c95fbe339f4bb8822f9745",
+        "original_path": "coalib/bears/LocalBear.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "coalib/settings/SectionFilling.py",
+        "path": "coalib/bears/LocalBear.py",
         "type": "file",
-        "name": "SectionFilling.py",
-        "size": 3942,
-        "sha1": "854be00b87187803b6d311592d2842b3ba07be0b",
-        "fingerprint": "931e5295cb2424b587c042a0173295ea",
-        "original_path": "coalib/settings/SectionFilling.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 14"
-      ],
-      "score": 34,
-      "new": {
-        "path": "coalib/misc/BuildManPage.py",
-        "type": "file",
-        "name": "BuildManPage.py",
-        "size": 7292,
-        "sha1": "6721970468b56d6207d4e78d030d62964ec15c19",
-        "fingerprint": "6398f0b71b781e40fe8d62c098fcef51",
-        "original_path": "coalib/misc/BuildManPage.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "coalib/misc/BuildManPage.py",
-        "type": "file",
-        "name": "BuildManPage.py",
-        "size": 7292,
-        "sha1": "0ce03b82db96c5789f673e318e1d1946b6f04c4a",
-        "fingerprint": "6399f8b7db683e427e9d62c09cfccf17",
-        "original_path": "coalib/misc/BuildManPage.py",
+        "name": "LocalBear.py",
+        "size": 1523,
+        "sha1": "171aab7341ee0465c3353f651108e1ab8816778e",
+        "fingerprint": "566ef2ad89495fb6338f0bb5022d9f75",
+        "original_path": "coalib/bears/LocalBear.py",
         "licenses": [],
         "copyrights": []
       }
@@ -1592,24 +1563,53 @@
       ],
       "score": 34,
       "new": {
-        "path": "coalib/bears/LocalBear.py",
+        "path": "coalib/misc/BuildManPage.py",
         "type": "file",
-        "name": "LocalBear.py",
-        "size": 1522,
-        "sha1": "74c46b4dff0a0bfaddae3945bf3e247544032160",
-        "fingerprint": "526ef2ed89c95fbe339f4bb8822f9745",
-        "original_path": "coalib/bears/LocalBear.py",
+        "name": "BuildManPage.py",
+        "size": 7292,
+        "sha1": "6721970468b56d6207d4e78d030d62964ec15c19",
+        "fingerprint": "6398f0b71b781e40fe8d62c098fcef51",
+        "original_path": "coalib/misc/BuildManPage.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "coalib/bears/LocalBear.py",
+        "path": "coalib/misc/BuildManPage.py",
         "type": "file",
-        "name": "LocalBear.py",
-        "size": 1523,
-        "sha1": "171aab7341ee0465c3353f651108e1ab8816778e",
-        "fingerprint": "566ef2ad89495fb6338f0bb5022d9f75",
-        "original_path": "coalib/bears/LocalBear.py",
+        "name": "BuildManPage.py",
+        "size": 7292,
+        "sha1": "0ce03b82db96c5789f673e318e1d1946b6f04c4a",
+        "fingerprint": "6399f8b7db683e427e9d62c09cfccf17",
+        "original_path": "coalib/misc/BuildManPage.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 14"
+      ],
+      "score": 34,
+      "new": {
+        "path": "coalib/settings/SectionFilling.py",
+        "type": "file",
+        "name": "SectionFilling.py",
+        "size": 3855,
+        "sha1": "406a05444557923c22a51d98845ec747c331fb3b",
+        "fingerprint": "b15e32979b2434b587c04382173795ea",
+        "original_path": "coalib/settings/SectionFilling.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "coalib/settings/SectionFilling.py",
+        "type": "file",
+        "name": "SectionFilling.py",
+        "size": 3942,
+        "sha1": "854be00b87187803b6d311592d2842b3ba07be0b",
+        "fingerprint": "931e5295cb2424b587c042a0173295ea",
+        "original_path": "coalib/settings/SectionFilling.py",
         "licenses": [],
         "copyrights": []
       }
@@ -1679,35 +1679,6 @@
       ],
       "score": 32,
       "new": {
-        "path": "coalib/results/result_actions/ResultAction.py",
-        "type": "file",
-        "name": "ResultAction.py",
-        "size": 3516,
-        "sha1": "31a10f87341cb74870b8af8b82613a34a2b82ad5",
-        "fingerprint": "141141da4dea065aca5bdea1034e0b43",
-        "original_path": "coalib/results/result_actions/ResultAction.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "coalib/results/result_actions/ResultAction.py",
-        "type": "file",
-        "name": "ResultAction.py",
-        "size": 3534,
-        "sha1": "6bf770d692b451f5d0ccfc17b9dd24c82ac43745",
-        "fingerprint": "145051da4cea0672c65bdae10b4e0b63",
-        "original_path": "coalib/results/result_actions/ResultAction.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 12"
-      ],
-      "score": 32,
-      "new": {
         "path": "coalib/processes/BearRunning.py",
         "type": "file",
         "name": "BearRunning.py",
@@ -1726,6 +1697,35 @@
         "sha1": "fabf0293e99224ee9ddbdd5f41acc4e7c7e5fdc5",
         "fingerprint": "203314d87e007a0fea85a49889a2a0bf",
         "original_path": "coalib/processes/BearRunning.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 12"
+      ],
+      "score": 32,
+      "new": {
+        "path": "coalib/results/result_actions/ResultAction.py",
+        "type": "file",
+        "name": "ResultAction.py",
+        "size": 3516,
+        "sha1": "31a10f87341cb74870b8af8b82613a34a2b82ad5",
+        "fingerprint": "141141da4dea065aca5bdea1034e0b43",
+        "original_path": "coalib/results/result_actions/ResultAction.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "coalib/results/result_actions/ResultAction.py",
+        "type": "file",
+        "name": "ResultAction.py",
+        "size": 3534,
+        "sha1": "6bf770d692b451f5d0ccfc17b9dd24c82ac43745",
+        "fingerprint": "145051da4cea0672c65bdae10b4e0b63",
+        "original_path": "coalib/results/result_actions/ResultAction.py",
         "licenses": [],
         "copyrights": []
       }
@@ -1911,35 +1911,6 @@
       ],
       "score": 25,
       "new": {
-        "path": "coalib/misc/DictUtilities.py",
-        "type": "file",
-        "name": "DictUtilities.py",
-        "size": 1360,
-        "sha1": "3f6eee9b00534fb5e00d33daa0cef4ee78e2d8e8",
-        "fingerprint": "30b6a2201d37c7c3b0555ec265f387e1",
-        "original_path": "coalib/misc/DictUtilities.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "coalib/misc/DictUtilities.py",
-        "type": "file",
-        "name": "DictUtilities.py",
-        "size": 1355,
-        "sha1": "36522522c930d05c37f791fa08eaf3ebe50b65d5",
-        "fingerprint": "1036a2201d37c7c380155ec265f387e1",
-        "original_path": "coalib/misc/DictUtilities.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 5"
-      ],
-      "score": 25,
-      "new": {
         "path": "coalib/bearlib/languages/documentation/DocumentationExtraction.py",
         "type": "file",
         "name": "DocumentationExtraction.py",
@@ -1964,54 +1935,29 @@
     },
     {
       "status": "modified",
-      "factors": [],
-      "score": 20,
+      "factors": [
+        "Similar with hamming distance : 5"
+      ],
+      "score": 25,
       "new": {
-        "path": "coalib/coala_format.py",
+        "path": "coalib/misc/DictUtilities.py",
         "type": "file",
-        "name": "coala_format.py",
-        "size": 333,
-        "sha1": "c59222d40b4302f82e8eb6788f219a334625cf43",
-        "fingerprint": "56ecb3911ce8dac5664e2d9195a95ce9",
-        "original_path": "coalib/coala_format.py",
+        "name": "DictUtilities.py",
+        "size": 1360,
+        "sha1": "3f6eee9b00534fb5e00d33daa0cef4ee78e2d8e8",
+        "fingerprint": "30b6a2201d37c7c3b0555ec265f387e1",
+        "original_path": "coalib/misc/DictUtilities.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "coalib/coala_format.py",
+        "path": "coalib/misc/DictUtilities.py",
         "type": "file",
-        "name": "coala_format.py",
-        "size": 936,
-        "sha1": "051e0b0a86a44cd635eab43f17ae177a1b43b8b8",
-        "fingerprint": "98bdefba529fc5e3aa3ee9a26591efa7",
-        "original_path": "coalib/coala_format.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [],
-      "score": 20,
-      "new": {
-        "path": "coalib/processes/CONTROL_ELEMENT.py",
-        "type": "file",
-        "name": "CONTROL_ELEMENT.py",
-        "size": 114,
-        "sha1": "995ab40a1c599e2caec45622b76962b5818d844a",
-        "fingerprint": "8006008710218016c2c080c14f1002de",
-        "original_path": "coalib/processes/CONTROL_ELEMENT.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "coalib/processes/CONTROL_ELEMENT.py",
-        "type": "file",
-        "name": "CONTROL_ELEMENT.py",
-        "size": 114,
-        "sha1": "8830c48ff828d0d93a1e37b83f411fa3b8eb238a",
-        "fingerprint": "84424c804091b01202101c0a229c93de",
-        "original_path": "coalib/processes/CONTROL_ELEMENT.py",
+        "name": "DictUtilities.py",
+        "size": 1355,
+        "sha1": "36522522c930d05c37f791fa08eaf3ebe50b65d5",
+        "fingerprint": "1036a2201d37c7c380155ec265f387e1",
+        "original_path": "coalib/misc/DictUtilities.py",
         "licenses": [],
         "copyrights": []
       }
@@ -2048,24 +1994,24 @@
       "factors": [],
       "score": 20,
       "new": {
-        "path": "coalib/output/ConfWriter.py",
+        "path": "coalib/coala_ci.py",
         "type": "file",
-        "name": "ConfWriter.py",
-        "size": 3863,
-        "sha1": "78b36a2fffc65a68d341a7d1e3cb579fbe1ee98d",
-        "fingerprint": "abfc3a1f42a0c377551b84bf4cc783a4",
-        "original_path": "coalib/output/ConfWriter.py",
+        "name": "coala_ci.py",
+        "size": 347,
+        "sha1": "52f481718f2243f7f4e14fb0db8f8723dc0aad21",
+        "fingerprint": "76ae3600056afb4166a62fbdb5a87ca9",
+        "original_path": "coalib/coala_ci.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "coalib/output/ConfWriter.py",
+        "path": "coalib/coala_ci.py",
         "type": "file",
-        "name": "ConfWriter.py",
-        "size": 4015,
-        "sha1": "2ae75d42ae63cda2ee490434b995c6a93ad4a8a0",
-        "fingerprint": "febc7e7552bfc1b5fdb8a5bf49cd02a0",
-        "original_path": "coalib/output/ConfWriter.py",
+        "name": "coala_ci.py",
+        "size": 1268,
+        "sha1": "f2c064700aa6d83522cbe7eeef5f3fd47a0739d4",
+        "fingerprint": "98a9edaa529dc523723eedb665b7efaf",
+        "original_path": "coalib/coala_ci.py",
         "licenses": [],
         "copyrights": []
       }
@@ -2075,78 +2021,24 @@
       "factors": [],
       "score": 20,
       "new": {
-        "path": "coalib/bearlib/languages/__init__.py",
+        "path": "coalib/coala_format.py",
         "type": "file",
-        "name": "__init__.py",
-        "size": 482,
-        "sha1": "3da423cf13371426b088f06234a4cd7b626fb279",
-        "fingerprint": "609588b9fa84f8a4055e800e10f864a9",
-        "original_path": "coalib/bearlib/languages/__init__.py",
+        "name": "coala_format.py",
+        "size": 333,
+        "sha1": "c59222d40b4302f82e8eb6788f219a334625cf43",
+        "fingerprint": "56ecb3911ce8dac5664e2d9195a95ce9",
+        "original_path": "coalib/coala_format.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "coalib/bearlib/languages/__init__.py",
+        "path": "coalib/coala_format.py",
         "type": "file",
-        "name": "__init__.py",
-        "size": 86,
-        "sha1": "b5fd238b55022311cd4fcaa2635bf058a7a78660",
-        "fingerprint": "6895b8636b8cc861c715c67c7af609bb",
-        "original_path": "coalib/bearlib/languages/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [],
-      "score": 20,
-      "new": {
-        "path": "coalib/bearlib/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 5572,
-        "sha1": "bd4cd0f28d1785be355dde59c83d42dc78bd3f3d",
-        "fingerprint": "b2091c8b3333bde25a4b5b034e58fb8d",
-        "original_path": "coalib/bearlib/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "coalib/bearlib/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 211,
-        "sha1": "4cef36542f76d618ef6d258b2f1adc90e5d545da",
-        "fingerprint": "7688102f13925981f20810ae3e480c5f",
-        "original_path": "coalib/bearlib/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [],
-      "score": 20,
-      "new": {
-        "path": "coalib/bearlib/languages/LanguageDefinition.py",
-        "type": "file",
-        "name": "LanguageDefinition.py",
-        "size": 3575,
-        "sha1": "a324a9dce3e8de817d645034c54639f9d5469f5d",
-        "fingerprint": "a68abe4c37766d95085971b600bc25fc",
-        "original_path": "coalib/bearlib/languages/LanguageDefinition.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "coalib/bearlib/languages/LanguageDefinition.py",
-        "type": "file",
-        "name": "LanguageDefinition.py",
-        "size": 1438,
-        "sha1": "2536c0a6d2093e584da16f29873661c44f5e118e",
-        "fingerprint": "b786be2e33146975211d2015109cffc0",
-        "original_path": "coalib/bearlib/languages/LanguageDefinition.py",
+        "name": "coala_format.py",
+        "size": 936,
+        "sha1": "051e0b0a86a44cd635eab43f17ae177a1b43b8b8",
+        "fingerprint": "98bdefba529fc5e3aa3ee9a26591efa7",
+        "original_path": "coalib/coala_format.py",
         "licenses": [],
         "copyrights": []
       }
@@ -2183,24 +2075,105 @@
       "factors": [],
       "score": 20,
       "new": {
-        "path": "coalib/results/result_actions/PrintDebugMessageAction.py",
+        "path": "coalib/VERSION",
         "type": "file",
-        "name": "PrintDebugMessageAction.py",
-        "size": 611,
-        "sha1": "a1ecc5ccd67ea8fa01ae4939a96fdf26ea6db085",
-        "fingerprint": "f53a27949441065632d33041b8986116",
-        "original_path": "coalib/results/result_actions/PrintDebugMessageAction.py",
+        "name": "VERSION",
+        "size": 7,
+        "sha1": "5e19b8eeb6eabfe6b41ea1c9c1d1f983e0e2f4e7",
+        "fingerprint": "df91e475efb86aa58b6f3353472ec6e9",
+        "original_path": "coalib/VERSION",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "coalib/results/result_actions/PrintDebugMessageAction.py",
+        "path": "coalib/VERSION",
         "type": "file",
-        "name": "PrintDebugMessageAction.py",
-        "size": 511,
-        "sha1": "986c5f904a0ee78c85a71d96b6621e85e1a9a8fd",
-        "fingerprint": "356aafc67c4ac74f425c679fe2901cc6",
-        "original_path": "coalib/results/result_actions/PrintDebugMessageAction.py",
+        "name": "VERSION",
+        "size": 6,
+        "sha1": "8606c087f8b6f1684acd81984a1b1723c35f95c1",
+        "fingerprint": "1f9fea2088b09fd355ce4bac1ba93ee9",
+        "original_path": "coalib/VERSION",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [],
+      "score": 20,
+      "new": {
+        "path": "coalib/bearlib/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 5572,
+        "sha1": "bd4cd0f28d1785be355dde59c83d42dc78bd3f3d",
+        "fingerprint": "b2091c8b3333bde25a4b5b034e58fb8d",
+        "original_path": "coalib/bearlib/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "coalib/bearlib/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 211,
+        "sha1": "4cef36542f76d618ef6d258b2f1adc90e5d545da",
+        "fingerprint": "7688102f13925981f20810ae3e480c5f",
+        "original_path": "coalib/bearlib/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [],
+      "score": 20,
+      "new": {
+        "path": "coalib/bearlib/languages/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 482,
+        "sha1": "3da423cf13371426b088f06234a4cd7b626fb279",
+        "fingerprint": "609588b9fa84f8a4055e800e10f864a9",
+        "original_path": "coalib/bearlib/languages/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "coalib/bearlib/languages/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 86,
+        "sha1": "b5fd238b55022311cd4fcaa2635bf058a7a78660",
+        "fingerprint": "6895b8636b8cc861c715c67c7af609bb",
+        "original_path": "coalib/bearlib/languages/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [],
+      "score": 20,
+      "new": {
+        "path": "coalib/bearlib/languages/LanguageDefinition.py",
+        "type": "file",
+        "name": "LanguageDefinition.py",
+        "size": 3575,
+        "sha1": "a324a9dce3e8de817d645034c54639f9d5469f5d",
+        "fingerprint": "a68abe4c37766d95085971b600bc25fc",
+        "original_path": "coalib/bearlib/languages/LanguageDefinition.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "coalib/bearlib/languages/LanguageDefinition.py",
+        "type": "file",
+        "name": "LanguageDefinition.py",
+        "size": 1438,
+        "sha1": "2536c0a6d2093e584da16f29873661c44f5e118e",
+        "fingerprint": "b786be2e33146975211d2015109cffc0",
+        "original_path": "coalib/bearlib/languages/LanguageDefinition.py",
         "licenses": [],
         "copyrights": []
       }
@@ -2237,24 +2210,24 @@
       "factors": [],
       "score": 20,
       "new": {
-        "path": "coalib/coala_ci.py",
+        "path": "coalib/output/ConfWriter.py",
         "type": "file",
-        "name": "coala_ci.py",
-        "size": 347,
-        "sha1": "52f481718f2243f7f4e14fb0db8f8723dc0aad21",
-        "fingerprint": "76ae3600056afb4166a62fbdb5a87ca9",
-        "original_path": "coalib/coala_ci.py",
+        "name": "ConfWriter.py",
+        "size": 3863,
+        "sha1": "78b36a2fffc65a68d341a7d1e3cb579fbe1ee98d",
+        "fingerprint": "abfc3a1f42a0c377551b84bf4cc783a4",
+        "original_path": "coalib/output/ConfWriter.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "coalib/coala_ci.py",
+        "path": "coalib/output/ConfWriter.py",
         "type": "file",
-        "name": "coala_ci.py",
-        "size": 1268,
-        "sha1": "f2c064700aa6d83522cbe7eeef5f3fd47a0739d4",
-        "fingerprint": "98a9edaa529dc523723eedb665b7efaf",
-        "original_path": "coalib/coala_ci.py",
+        "name": "ConfWriter.py",
+        "size": 4015,
+        "sha1": "2ae75d42ae63cda2ee490434b995c6a93ad4a8a0",
+        "fingerprint": "febc7e7552bfc1b5fdb8a5bf49cd02a0",
+        "original_path": "coalib/output/ConfWriter.py",
         "licenses": [],
         "copyrights": []
       }
@@ -2264,78 +2237,24 @@
       "factors": [],
       "score": 20,
       "new": {
-        "path": "coalib/results/result_actions/OpenEditorAction.py",
+        "path": "coalib/output/Interactions.py",
         "type": "file",
-        "name": "OpenEditorAction.py",
-        "size": 6600,
-        "sha1": "54af25741b68793d7e1de649df2f4d3af29fe226",
-        "fingerprint": "7857b3cd10805181264ac3c48e55a1c6",
-        "original_path": "coalib/results/result_actions/OpenEditorAction.py",
+        "name": "Interactions.py",
+        "size": 1200,
+        "sha1": "78e7d4892841a6cd70263edda3ae92f03ce940b4",
+        "fingerprint": "f8746a3f6923ce88c5fb13fd43a6d335",
+        "original_path": "coalib/output/Interactions.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "coalib/results/result_actions/OpenEditorAction.py",
+        "path": "coalib/output/Interactions.py",
         "type": "file",
-        "name": "OpenEditorAction.py",
-        "size": 2125,
-        "sha1": "e0d186c0b4c6fcc6de680748ddae536e0ea08db3",
-        "fingerprint": "8965a1b3265a811555f9e6f686de63a6",
-        "original_path": "coalib/results/result_actions/OpenEditorAction.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [],
-      "score": 20,
-      "new": {
-        "path": "coalib/results/result_actions/ShowPatchAction.py",
-        "type": "file",
-        "name": "ShowPatchAction.py",
-        "size": 5296,
-        "sha1": "ec36c7e6df5d74b9435bfc9cb2fccf3951e31f0d",
-        "fingerprint": "7dd10ee480e78033fd2ef2c618d22118",
-        "original_path": "coalib/results/result_actions/ShowPatchAction.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "coalib/results/result_actions/ShowPatchAction.py",
-        "type": "file",
-        "name": "ShowPatchAction.py",
-        "size": 4291,
-        "sha1": "676d5e5de8850d9fbf10cf74af84148c17da9734",
-        "fingerprint": "2b714700258b20a7d93480c64620011e",
-        "original_path": "coalib/results/result_actions/ShowPatchAction.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [],
-      "score": 20,
-      "new": {
-        "path": "coalib/results/Result.py",
-        "type": "file",
-        "name": "Result.py",
-        "size": 11406,
-        "sha1": "5317d7eb908266c1ef7fa49414bd9124a4e2845a",
-        "fingerprint": "4d94a2b28c68cf64907c2b8daaf4235f",
-        "original_path": "coalib/results/Result.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "coalib/results/Result.py",
-        "type": "file",
-        "name": "Result.py",
-        "size": 8637,
-        "sha1": "52192b2cd2a12bd23a26ff48ea20a3675f674ca3",
-        "fingerprint": "0f906ab5d4acc96d80be2b04f6f67f63",
-        "original_path": "coalib/results/Result.py",
+        "name": "Interactions.py",
+        "size": 1191,
+        "sha1": "cea2ad6687ba74016a94e4077b6a691220acae7f",
+        "fingerprint": "29b16f5c4923844099fb15e14aa28176",
+        "original_path": "coalib/output/Interactions.py",
         "licenses": [],
         "copyrights": []
       }
@@ -2399,24 +2318,24 @@
       "factors": [],
       "score": 20,
       "new": {
-        "path": "coalib/results/result_actions/PrintMoreInfoAction.py",
+        "path": "coalib/processes/CONTROL_ELEMENT.py",
         "type": "file",
-        "name": "PrintMoreInfoAction.py",
-        "size": 617,
-        "sha1": "40f610cbffe9d778df814c02cf2cc18b4efdc8fe",
-        "fingerprint": "375a2fdc90444a862a41f063b8d00035",
-        "original_path": "coalib/results/result_actions/PrintMoreInfoAction.py",
+        "name": "CONTROL_ELEMENT.py",
+        "size": 114,
+        "sha1": "995ab40a1c599e2caec45622b76962b5818d844a",
+        "fingerprint": "8006008710218016c2c080c14f1002de",
+        "original_path": "coalib/processes/CONTROL_ELEMENT.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "coalib/results/result_actions/PrintMoreInfoAction.py",
+        "path": "coalib/processes/CONTROL_ELEMENT.py",
         "type": "file",
-        "name": "PrintMoreInfoAction.py",
-        "size": 530,
-        "sha1": "b81493f315271c5d357ba2b5f1a723cef2a070f4",
-        "fingerprint": "2f7adfe45862d150c35077ebc2b02b76",
-        "original_path": "coalib/results/result_actions/PrintMoreInfoAction.py",
+        "name": "CONTROL_ELEMENT.py",
+        "size": 114,
+        "sha1": "8830c48ff828d0d93a1e37b83f411fa3b8eb238a",
+        "fingerprint": "84424c804091b01202101c0a229c93de",
+        "original_path": "coalib/processes/CONTROL_ELEMENT.py",
         "licenses": [],
         "copyrights": []
       }
@@ -2426,51 +2345,24 @@
       "factors": [],
       "score": 20,
       "new": {
-        "path": "coalib/output/Interactions.py",
+        "path": "coalib/results/Result.py",
         "type": "file",
-        "name": "Interactions.py",
-        "size": 1200,
-        "sha1": "78e7d4892841a6cd70263edda3ae92f03ce940b4",
-        "fingerprint": "f8746a3f6923ce88c5fb13fd43a6d335",
-        "original_path": "coalib/output/Interactions.py",
+        "name": "Result.py",
+        "size": 11406,
+        "sha1": "5317d7eb908266c1ef7fa49414bd9124a4e2845a",
+        "fingerprint": "4d94a2b28c68cf64907c2b8daaf4235f",
+        "original_path": "coalib/results/Result.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "coalib/output/Interactions.py",
+        "path": "coalib/results/Result.py",
         "type": "file",
-        "name": "Interactions.py",
-        "size": 1191,
-        "sha1": "cea2ad6687ba74016a94e4077b6a691220acae7f",
-        "fingerprint": "29b16f5c4923844099fb15e14aa28176",
-        "original_path": "coalib/output/Interactions.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [],
-      "score": 20,
-      "new": {
-        "path": "coalib/VERSION",
-        "type": "file",
-        "name": "VERSION",
-        "size": 7,
-        "sha1": "5e19b8eeb6eabfe6b41ea1c9c1d1f983e0e2f4e7",
-        "fingerprint": "df91e475efb86aa58b6f3353472ec6e9",
-        "original_path": "coalib/VERSION",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "coalib/VERSION",
-        "type": "file",
-        "name": "VERSION",
-        "size": 6,
-        "sha1": "8606c087f8b6f1684acd81984a1b1723c35f95c1",
-        "fingerprint": "1f9fea2088b09fd355ce4bac1ba93ee9",
-        "original_path": "coalib/VERSION",
+        "name": "Result.py",
+        "size": 8637,
+        "sha1": "52192b2cd2a12bd23a26ff48ea20a3675f674ca3",
+        "fingerprint": "0f906ab5d4acc96d80be2b04f6f67f63",
+        "original_path": "coalib/results/Result.py",
         "licenses": [],
         "copyrights": []
       }
@@ -2503,55 +2395,109 @@
       }
     },
     {
-      "status": "unmodified",
+      "status": "modified",
       "factors": [],
-      "score": 0,
+      "score": 20,
       "new": {
-        "path": "coalib/parsing/__init__.py",
+        "path": "coalib/results/result_actions/OpenEditorAction.py",
         "type": "file",
-        "name": "__init__.py",
-        "size": 167,
-        "sha1": "1d6888393b8f538d29e3a058f308ff1f62fb72b2",
-        "fingerprint": "6aa21401c620cd8a33708dc97662c0c1",
-        "original_path": "coalib/parsing/__init__.py",
+        "name": "OpenEditorAction.py",
+        "size": 6600,
+        "sha1": "54af25741b68793d7e1de649df2f4d3af29fe226",
+        "fingerprint": "7857b3cd10805181264ac3c48e55a1c6",
+        "original_path": "coalib/results/result_actions/OpenEditorAction.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "coalib/parsing/__init__.py",
+        "path": "coalib/results/result_actions/OpenEditorAction.py",
         "type": "file",
-        "name": "__init__.py",
-        "size": 167,
-        "sha1": "1d6888393b8f538d29e3a058f308ff1f62fb72b2",
-        "fingerprint": "6aa21401c620cd8a33708dc97662c0c1",
-        "original_path": "coalib/parsing/__init__.py",
+        "name": "OpenEditorAction.py",
+        "size": 2125,
+        "sha1": "e0d186c0b4c6fcc6de680748ddae536e0ea08db3",
+        "fingerprint": "8965a1b3265a811555f9e6f686de63a6",
+        "original_path": "coalib/results/result_actions/OpenEditorAction.py",
         "licenses": [],
         "copyrights": []
       }
     },
     {
-      "status": "unmodified",
+      "status": "modified",
       "factors": [],
-      "score": 0,
+      "score": 20,
       "new": {
-        "path": "coalib/bearlib/spacing/__init__.py",
+        "path": "coalib/results/result_actions/PrintDebugMessageAction.py",
         "type": "file",
-        "name": "__init__.py",
-        "size": 0,
-        "sha1": null,
-        "fingerprint": null,
-        "original_path": "coalib/bearlib/spacing/__init__.py",
+        "name": "PrintDebugMessageAction.py",
+        "size": 611,
+        "sha1": "a1ecc5ccd67ea8fa01ae4939a96fdf26ea6db085",
+        "fingerprint": "f53a27949441065632d33041b8986116",
+        "original_path": "coalib/results/result_actions/PrintDebugMessageAction.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "coalib/bearlib/spacing/__init__.py",
+        "path": "coalib/results/result_actions/PrintDebugMessageAction.py",
         "type": "file",
-        "name": "__init__.py",
-        "size": 0,
-        "sha1": null,
-        "fingerprint": null,
-        "original_path": "coalib/bearlib/spacing/__init__.py",
+        "name": "PrintDebugMessageAction.py",
+        "size": 511,
+        "sha1": "986c5f904a0ee78c85a71d96b6621e85e1a9a8fd",
+        "fingerprint": "356aafc67c4ac74f425c679fe2901cc6",
+        "original_path": "coalib/results/result_actions/PrintDebugMessageAction.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [],
+      "score": 20,
+      "new": {
+        "path": "coalib/results/result_actions/PrintMoreInfoAction.py",
+        "type": "file",
+        "name": "PrintMoreInfoAction.py",
+        "size": 617,
+        "sha1": "40f610cbffe9d778df814c02cf2cc18b4efdc8fe",
+        "fingerprint": "375a2fdc90444a862a41f063b8d00035",
+        "original_path": "coalib/results/result_actions/PrintMoreInfoAction.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "coalib/results/result_actions/PrintMoreInfoAction.py",
+        "type": "file",
+        "name": "PrintMoreInfoAction.py",
+        "size": 530,
+        "sha1": "b81493f315271c5d357ba2b5f1a723cef2a070f4",
+        "fingerprint": "2f7adfe45862d150c35077ebc2b02b76",
+        "original_path": "coalib/results/result_actions/PrintMoreInfoAction.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [],
+      "score": 20,
+      "new": {
+        "path": "coalib/results/result_actions/ShowPatchAction.py",
+        "type": "file",
+        "name": "ShowPatchAction.py",
+        "size": 5296,
+        "sha1": "ec36c7e6df5d74b9435bfc9cb2fccf3951e31f0d",
+        "fingerprint": "7dd10ee480e78033fd2ef2c618d22118",
+        "original_path": "coalib/results/result_actions/ShowPatchAction.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "coalib/results/result_actions/ShowPatchAction.py",
+        "type": "file",
+        "name": "ShowPatchAction.py",
+        "size": 4291,
+        "sha1": "676d5e5de8850d9fbf10cf74af84148c17da9734",
+        "fingerprint": "2b714700258b20a7d93480c64620011e",
+        "original_path": "coalib/results/result_actions/ShowPatchAction.py",
         "licenses": [],
         "copyrights": []
       }
@@ -2588,303 +2534,6 @@
       "factors": [],
       "score": 0,
       "new": {
-        "path": "coalib/bearlib/languages/documentation/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 131,
-        "sha1": "eb5fe0a696ffb1729c1d59ca79c7c8c41294b6a5",
-        "fingerprint": "4efe1f6ffd1ceb9b41961ab0345dd9f8",
-        "original_path": "coalib/bearlib/languages/documentation/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "coalib/bearlib/languages/documentation/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 131,
-        "sha1": "eb5fe0a696ffb1729c1d59ca79c7c8c41294b6a5",
-        "fingerprint": "4efe1f6ffd1ceb9b41961ab0345dd9f8",
-        "original_path": "coalib/bearlib/languages/documentation/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "unmodified",
-      "factors": [],
-      "score": 0,
-      "new": {
-        "path": "coalib/processes/communication/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 0,
-        "sha1": null,
-        "fingerprint": null,
-        "original_path": "coalib/processes/communication/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "coalib/processes/communication/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 0,
-        "sha1": null,
-        "fingerprint": null,
-        "original_path": "coalib/processes/communication/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "unmodified",
-      "factors": [],
-      "score": 0,
-      "new": {
-        "path": "coalib/output/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 0,
-        "sha1": null,
-        "fingerprint": null,
-        "original_path": "coalib/output/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "coalib/output/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 0,
-        "sha1": null,
-        "fingerprint": null,
-        "original_path": "coalib/output/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "unmodified",
-      "factors": [],
-      "score": 0,
-      "new": {
-        "path": "coalib/collecting/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 0,
-        "sha1": null,
-        "fingerprint": null,
-        "original_path": "coalib/collecting/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "coalib/collecting/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 0,
-        "sha1": null,
-        "fingerprint": null,
-        "original_path": "coalib/collecting/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "unmodified",
-      "factors": [],
-      "score": 0,
-      "new": {
-        "path": "coalib/processes/LogPrinterThread.py",
-        "type": "file",
-        "name": "LogPrinterThread.py",
-        "size": 688,
-        "sha1": "8fcd1e4e74eec575a4ee1d15d3b28c06e26c26da",
-        "fingerprint": "f0d01ba11529060bfb94e1f0e3245155",
-        "original_path": "coalib/processes/LogPrinterThread.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "coalib/processes/LogPrinterThread.py",
-        "type": "file",
-        "name": "LogPrinterThread.py",
-        "size": 688,
-        "sha1": "8fcd1e4e74eec575a4ee1d15d3b28c06e26c26da",
-        "fingerprint": "f0d01ba11529060bfb94e1f0e3245155",
-        "original_path": "coalib/processes/LogPrinterThread.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "unmodified",
-      "factors": [],
-      "score": 0,
-      "new": {
-        "path": "coalib/misc/Enum.py",
-        "type": "file",
-        "name": "Enum.py",
-        "size": 270,
-        "sha1": "77579568fabc8ccb3d3e9476fea5f01f862066d9",
-        "fingerprint": "10eb976a00693bd4b34767452d4fda24",
-        "original_path": "coalib/misc/Enum.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "coalib/misc/Enum.py",
-        "type": "file",
-        "name": "Enum.py",
-        "size": 270,
-        "sha1": "77579568fabc8ccb3d3e9476fea5f01f862066d9",
-        "fingerprint": "10eb976a00693bd4b34767452d4fda24",
-        "original_path": "coalib/misc/Enum.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "unmodified",
-      "factors": [],
-      "score": 0,
-      "new": {
-        "path": "coalib/results/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 0,
-        "sha1": null,
-        "fingerprint": null,
-        "original_path": "coalib/results/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "coalib/results/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 0,
-        "sha1": null,
-        "fingerprint": null,
-        "original_path": "coalib/results/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "unmodified",
-      "factors": [],
-      "score": 0,
-      "new": {
-        "path": "coalib/output/printers/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 269,
-        "sha1": "5d2e282a3771dc975bef6a32cf338ad62500f421",
-        "fingerprint": "6119f362803a91b51636b9a32efe15e7",
-        "original_path": "coalib/output/printers/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "coalib/output/printers/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 269,
-        "sha1": "5d2e282a3771dc975bef6a32cf338ad62500f421",
-        "fingerprint": "6119f362803a91b51636b9a32efe15e7",
-        "original_path": "coalib/output/printers/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "unmodified",
-      "factors": [],
-      "score": 0,
-      "new": {
-        "path": "coalib/settings/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 0,
-        "sha1": null,
-        "fingerprint": null,
-        "original_path": "coalib/settings/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "coalib/settings/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 0,
-        "sha1": null,
-        "fingerprint": null,
-        "original_path": "coalib/settings/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "unmodified",
-      "factors": [],
-      "score": 0,
-      "new": {
-        "path": "coalib/bears/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 0,
-        "sha1": null,
-        "fingerprint": null,
-        "original_path": "coalib/bears/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "coalib/bears/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 0,
-        "sha1": null,
-        "fingerprint": null,
-        "original_path": "coalib/bears/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "unmodified",
-      "factors": [],
-      "score": 0,
-      "new": {
-        "path": "coalib/misc/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 0,
-        "sha1": null,
-        "fingerprint": null,
-        "original_path": "coalib/misc/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "coalib/misc/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 0,
-        "sha1": null,
-        "fingerprint": null,
-        "original_path": "coalib/misc/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "unmodified",
-      "factors": [],
-      "score": 0,
-      "new": {
         "path": "coalib/bearlib/abstractions/__init__.py",
         "type": "file",
         "name": "__init__.py",
@@ -2903,33 +2552,6 @@
         "sha1": "7470ffdc8bb4a378866338e5ab0e14789b8dcb6a",
         "fingerprint": "155828fa383550138b34f6cef327030c",
         "original_path": "coalib/bearlib/abstractions/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "unmodified",
-      "factors": [],
-      "score": 0,
-      "new": {
-        "path": "coalib/results/result_actions/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 145,
-        "sha1": "9db16072266575f9881dfbbafecdf8ab7a14cdb0",
-        "fingerprint": "20ca18b5604a47298a558b045295210b",
-        "original_path": "coalib/results/result_actions/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "coalib/results/result_actions/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 145,
-        "sha1": "9db16072266575f9881dfbbafecdf8ab7a14cdb0",
-        "fingerprint": "20ca18b5604a47298a558b045295210b",
-        "original_path": "coalib/results/result_actions/__init__.py",
         "licenses": [],
         "copyrights": []
       }
@@ -2966,6 +2588,249 @@
       "factors": [],
       "score": 0,
       "new": {
+        "path": "coalib/bearlib/languages/documentation/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 131,
+        "sha1": "eb5fe0a696ffb1729c1d59ca79c7c8c41294b6a5",
+        "fingerprint": "4efe1f6ffd1ceb9b41961ab0345dd9f8",
+        "original_path": "coalib/bearlib/languages/documentation/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "coalib/bearlib/languages/documentation/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 131,
+        "sha1": "eb5fe0a696ffb1729c1d59ca79c7c8c41294b6a5",
+        "fingerprint": "4efe1f6ffd1ceb9b41961ab0345dd9f8",
+        "original_path": "coalib/bearlib/languages/documentation/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "unmodified",
+      "factors": [],
+      "score": 0,
+      "new": {
+        "path": "coalib/bearlib/spacing/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 0,
+        "sha1": null,
+        "fingerprint": null,
+        "original_path": "coalib/bearlib/spacing/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "coalib/bearlib/spacing/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 0,
+        "sha1": null,
+        "fingerprint": null,
+        "original_path": "coalib/bearlib/spacing/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "unmodified",
+      "factors": [],
+      "score": 0,
+      "new": {
+        "path": "coalib/bears/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 0,
+        "sha1": null,
+        "fingerprint": null,
+        "original_path": "coalib/bears/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "coalib/bears/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 0,
+        "sha1": null,
+        "fingerprint": null,
+        "original_path": "coalib/bears/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "unmodified",
+      "factors": [],
+      "score": 0,
+      "new": {
+        "path": "coalib/collecting/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 0,
+        "sha1": null,
+        "fingerprint": null,
+        "original_path": "coalib/collecting/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "coalib/collecting/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 0,
+        "sha1": null,
+        "fingerprint": null,
+        "original_path": "coalib/collecting/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "unmodified",
+      "factors": [],
+      "score": 0,
+      "new": {
+        "path": "coalib/misc/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 0,
+        "sha1": null,
+        "fingerprint": null,
+        "original_path": "coalib/misc/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "coalib/misc/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 0,
+        "sha1": null,
+        "fingerprint": null,
+        "original_path": "coalib/misc/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "unmodified",
+      "factors": [],
+      "score": 0,
+      "new": {
+        "path": "coalib/misc/Enum.py",
+        "type": "file",
+        "name": "Enum.py",
+        "size": 270,
+        "sha1": "77579568fabc8ccb3d3e9476fea5f01f862066d9",
+        "fingerprint": "10eb976a00693bd4b34767452d4fda24",
+        "original_path": "coalib/misc/Enum.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "coalib/misc/Enum.py",
+        "type": "file",
+        "name": "Enum.py",
+        "size": 270,
+        "sha1": "77579568fabc8ccb3d3e9476fea5f01f862066d9",
+        "fingerprint": "10eb976a00693bd4b34767452d4fda24",
+        "original_path": "coalib/misc/Enum.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "unmodified",
+      "factors": [],
+      "score": 0,
+      "new": {
+        "path": "coalib/output/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 0,
+        "sha1": null,
+        "fingerprint": null,
+        "original_path": "coalib/output/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "coalib/output/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 0,
+        "sha1": null,
+        "fingerprint": null,
+        "original_path": "coalib/output/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "unmodified",
+      "factors": [],
+      "score": 0,
+      "new": {
+        "path": "coalib/output/printers/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 269,
+        "sha1": "5d2e282a3771dc975bef6a32cf338ad62500f421",
+        "fingerprint": "6119f362803a91b51636b9a32efe15e7",
+        "original_path": "coalib/output/printers/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "coalib/output/printers/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 269,
+        "sha1": "5d2e282a3771dc975bef6a32cf338ad62500f421",
+        "fingerprint": "6119f362803a91b51636b9a32efe15e7",
+        "original_path": "coalib/output/printers/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "unmodified",
+      "factors": [],
+      "score": 0,
+      "new": {
+        "path": "coalib/parsing/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 167,
+        "sha1": "1d6888393b8f538d29e3a058f308ff1f62fb72b2",
+        "fingerprint": "6aa21401c620cd8a33708dc97662c0c1",
+        "original_path": "coalib/parsing/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "coalib/parsing/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 167,
+        "sha1": "1d6888393b8f538d29e3a058f308ff1f62fb72b2",
+        "fingerprint": "6aa21401c620cd8a33708dc97662c0c1",
+        "original_path": "coalib/parsing/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "unmodified",
+      "factors": [],
+      "score": 0,
+      "new": {
         "path": "coalib/processes/__init__.py",
         "type": "file",
         "name": "__init__.py",
@@ -2989,18 +2854,136 @@
       }
     },
     {
-      "status": "removed",
+      "status": "unmodified",
       "factors": [],
       "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/bears/requirements/PipRequirement.py",
+      "new": {
+        "path": "coalib/processes/LogPrinterThread.py",
         "type": "file",
-        "name": "PipRequirement.py",
-        "size": 847,
-        "sha1": "2de354930248f786449c8a1993af9f3564c6afd3",
-        "fingerprint": "1130f2506e1a4420c209dbc61a285300",
-        "original_path": "coalib/bears/requirements/PipRequirement.py",
+        "name": "LogPrinterThread.py",
+        "size": 688,
+        "sha1": "8fcd1e4e74eec575a4ee1d15d3b28c06e26c26da",
+        "fingerprint": "f0d01ba11529060bfb94e1f0e3245155",
+        "original_path": "coalib/processes/LogPrinterThread.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "coalib/processes/LogPrinterThread.py",
+        "type": "file",
+        "name": "LogPrinterThread.py",
+        "size": 688,
+        "sha1": "8fcd1e4e74eec575a4ee1d15d3b28c06e26c26da",
+        "fingerprint": "f0d01ba11529060bfb94e1f0e3245155",
+        "original_path": "coalib/processes/LogPrinterThread.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "unmodified",
+      "factors": [],
+      "score": 0,
+      "new": {
+        "path": "coalib/processes/communication/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 0,
+        "sha1": null,
+        "fingerprint": null,
+        "original_path": "coalib/processes/communication/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "coalib/processes/communication/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 0,
+        "sha1": null,
+        "fingerprint": null,
+        "original_path": "coalib/processes/communication/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "unmodified",
+      "factors": [],
+      "score": 0,
+      "new": {
+        "path": "coalib/results/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 0,
+        "sha1": null,
+        "fingerprint": null,
+        "original_path": "coalib/results/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "coalib/results/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 0,
+        "sha1": null,
+        "fingerprint": null,
+        "original_path": "coalib/results/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "unmodified",
+      "factors": [],
+      "score": 0,
+      "new": {
+        "path": "coalib/results/result_actions/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 145,
+        "sha1": "9db16072266575f9881dfbbafecdf8ab7a14cdb0",
+        "fingerprint": "20ca18b5604a47298a558b045295210b",
+        "original_path": "coalib/results/result_actions/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "coalib/results/result_actions/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 145,
+        "sha1": "9db16072266575f9881dfbbafecdf8ab7a14cdb0",
+        "fingerprint": "20ca18b5604a47298a558b045295210b",
+        "original_path": "coalib/results/result_actions/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "unmodified",
+      "factors": [],
+      "score": 0,
+      "new": {
+        "path": "coalib/settings/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 0,
+        "sha1": null,
+        "fingerprint": null,
+        "original_path": "coalib/settings/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "coalib/settings/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 0,
+        "sha1": null,
+        "fingerprint": null,
+        "original_path": "coalib/settings/__init__.py",
         "licenses": [],
         "copyrights": []
       }
@@ -3018,6 +3001,74 @@
         "sha1": "12ba867dde148a67cf9fd14c54530486ae6a6c67",
         "fingerprint": "8ebbe7fa569dd7f2aabeede55593c9af",
         "original_path": "coalib/coala_dbus.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/bearlib/abstractions/Lint.py",
+        "type": "file",
+        "name": "Lint.py",
+        "size": 15710,
+        "sha1": "b430f0c735ca261779204a76e88658c21a6e8210",
+        "fingerprint": "b0e3971ba8512f7e537c6ccf699b5ab2",
+        "original_path": "coalib/bearlib/abstractions/Lint.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/bearlib/languages/definitions/c.coalang",
+        "type": "file",
+        "name": "c.coalang",
+        "size": 568,
+        "sha1": "a6f2eeb3d4a7a983bdec457cf438bebc5e96d429",
+        "fingerprint": "8d91eb5c609d76bddaf1c2443983596c",
+        "original_path": "coalib/bearlib/languages/definitions/c.coalang",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/bearlib/languages/definitions/cpp.coalang",
+        "type": "file",
+        "name": "cpp.coalang",
+        "size": 1057,
+        "sha1": "eeae9b0805d0a73ec9776ca22b167b4c35fbd9d4",
+        "fingerprint": "4c81f332400813355093b2419a3219a5",
+        "original_path": "coalib/bearlib/languages/definitions/cpp.coalang",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/bearlib/languages/definitions/python3.coalang",
+        "type": "file",
+        "name": "python3.coalang",
+        "size": 197,
+        "sha1": "9d2b3693ee8ce866ce05f33132f9139d8effe113",
+        "fingerprint": "4e13ff2ee8b1291acebd8a25322f308a",
+        "original_path": "coalib/bearlib/languages/definitions/python3.coalang",
         "licenses": [],
         "copyrights": []
       }
@@ -3062,176 +3113,6 @@
       "score": 0,
       "new": null,
       "old": {
-        "path": "coalib/bearlib/languages/definitions/python3.coalang",
-        "type": "file",
-        "name": "python3.coalang",
-        "size": 197,
-        "sha1": "9d2b3693ee8ce866ce05f33132f9139d8effe113",
-        "fingerprint": "4e13ff2ee8b1291acebd8a25322f308a",
-        "original_path": "coalib/bearlib/languages/definitions/python3.coalang",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/parsing/StringProcessing/Core.py",
-        "type": "file",
-        "name": "Core.py",
-        "size": 21420,
-        "sha1": "9bc4ee2efb4030a110eee77aa93340bcc523d142",
-        "fingerprint": "43722cfbf2f6d56ca294653b1e16af80",
-        "original_path": "coalib/parsing/StringProcessing/Core.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/parsing/StringProcessing/Match.py",
-        "type": "file",
-        "name": "Match.py",
-        "size": 1541,
-        "sha1": "a1a68427837dd34b3bc40e4c716238da4b206efa",
-        "fingerprint": "0c2a9e5e8470895acfa04d7607158532",
-        "original_path": "coalib/parsing/StringProcessing/Match.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/bearlib/languages/definitions/cpp.coalang",
-        "type": "file",
-        "name": "cpp.coalang",
-        "size": 1057,
-        "sha1": "eeae9b0805d0a73ec9776ca22b167b4c35fbd9d4",
-        "fingerprint": "4c81f332400813355093b2419a3219a5",
-        "original_path": "coalib/bearlib/languages/definitions/cpp.coalang",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/parsing/StringProcessing/InBetweenMatch.py",
-        "type": "file",
-        "name": "InBetweenMatch.py",
-        "size": 2120,
-        "sha1": "8a30603a995eb98fdb520b6ea1c8ea87be369c59",
-        "fingerprint": "24530d0b9ff122277ff62d13250ecc8b",
-        "original_path": "coalib/parsing/StringProcessing/InBetweenMatch.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/output/dbus/DbusServer.py",
-        "type": "file",
-        "name": "DbusServer.py",
-        "size": 5769,
-        "sha1": "d16266087223a9556f6e4781e69de390068dfe06",
-        "fingerprint": "b000c2408994a39d58cfbd1d6344e536",
-        "original_path": "coalib/output/dbus/DbusServer.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/bearlib/abstractions/Lint.py",
-        "type": "file",
-        "name": "Lint.py",
-        "size": 15710,
-        "sha1": "b430f0c735ca261779204a76e88658c21a6e8210",
-        "fingerprint": "b0e3971ba8512f7e537c6ccf699b5ab2",
-        "original_path": "coalib/bearlib/abstractions/Lint.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/misc/MutableValue.py",
-        "type": "file",
-        "name": "MutableValue.py",
-        "size": 80,
-        "sha1": "4897a234c35f97cc6782289bd289f7b79962d292",
-        "fingerprint": "2ea13e761002738040a4a408074e2143",
-        "original_path": "coalib/misc/MutableValue.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/parsing/StringProcessing/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 1082,
-        "sha1": "fbd024543ce29cc0fedc6ad396a10d64a7a61128",
-        "fingerprint": "344d7f56111c282cbcde92929e63e141",
-        "original_path": "coalib/parsing/StringProcessing/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/output/dbus/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 561,
-        "sha1": "727f8b13d15f98f72c6dc45aaa76ce1d209a6b90",
-        "fingerprint": "13b5a7360a43dd189f681c5ea9a850ae",
-        "original_path": "coalib/output/dbus/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
         "path": "coalib/bears/requirements/PackageRequirement.py",
         "type": "file",
         "name": "PackageRequirement.py",
@@ -3249,81 +3130,13 @@
       "score": 0,
       "new": null,
       "old": {
-        "path": "coalib/misc/ContextManagers.py",
+        "path": "coalib/bears/requirements/PipRequirement.py",
         "type": "file",
-        "name": "ContextManagers.py",
-        "size": 7320,
-        "sha1": "2f96b9fafe873fbf4fe728ec3bee297b76b23ad3",
-        "fingerprint": "59ae0f94aaf016681f9b4e334b93d871",
-        "original_path": "coalib/misc/ContextManagers.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/output/dbus/BuildDbusService.py",
-        "type": "file",
-        "name": "BuildDbusService.py",
-        "size": 1411,
-        "sha1": "50d4a97f5b22a668fa6b32a5439d895395e35ed8",
-        "fingerprint": "f396d383c00c04c29308444c18fa4b61",
-        "original_path": "coalib/output/dbus/BuildDbusService.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/output/dbus/DbusDocument.py",
-        "type": "file",
-        "name": "DbusDocument.py",
-        "size": 6938,
-        "sha1": "c785c58df4bb36e11204298b08fd11706fec0537",
-        "fingerprint": "76b6e667cc3be1d65dfbb3ce78a6708b",
-        "original_path": "coalib/output/dbus/DbusDocument.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/misc/StringConverter.py",
-        "type": "file",
-        "name": "StringConverter.py",
-        "size": 5054,
-        "sha1": "c631950e218cab444d1493617a65a12b00364881",
-        "fingerprint": "ea9a8d1344c48ce23d4fb5e986e50a88",
-        "original_path": "coalib/misc/StringConverter.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/parsing/StringProcessing/Filters.py",
-        "type": "file",
-        "name": "Filters.py",
-        "size": 1331,
-        "sha1": "d6c829ce09c42b1f32c80427656ecc2571ba86a9",
-        "fingerprint": "a60f7b72ef38d44cb9ed9093571f9043",
-        "original_path": "coalib/parsing/StringProcessing/Filters.py",
+        "name": "PipRequirement.py",
+        "size": 847,
+        "sha1": "2de354930248f786449c8a1993af9f3564c6afd3",
+        "fingerprint": "1130f2506e1a4420c209dbc61a285300",
+        "original_path": "coalib/bears/requirements/PipRequirement.py",
         "licenses": [],
         "copyrights": []
       }
@@ -3351,30 +3164,13 @@
       "score": 0,
       "new": null,
       "old": {
-        "path": "coalib/output/dbus/DbusApp.py",
+        "path": "coalib/misc/ContextManagers.py",
         "type": "file",
-        "name": "DbusApp.py",
-        "size": 1509,
-        "sha1": "3549f039b292fbefdf45c2c487b3695daaec594f",
-        "fingerprint": "3315270d0f17234d9838f3542645e550",
-        "original_path": "coalib/output/dbus/DbusApp.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/bearlib/languages/definitions/c.coalang",
-        "type": "file",
-        "name": "c.coalang",
-        "size": 568,
-        "sha1": "a6f2eeb3d4a7a983bdec457cf438bebc5e96d429",
-        "fingerprint": "8d91eb5c609d76bddaf1c2443983596c",
-        "original_path": "coalib/bearlib/languages/definitions/c.coalang",
+        "name": "ContextManagers.py",
+        "size": 7320,
+        "sha1": "2f96b9fafe873fbf4fe728ec3bee297b76b23ad3",
+        "fingerprint": "59ae0f94aaf016681f9b4e334b93d871",
+        "original_path": "coalib/misc/ContextManagers.py",
         "licenses": [],
         "copyrights": []
       }
@@ -3392,6 +3188,210 @@
         "sha1": "c07134749c576cb2dbf33be37951e01f96763a25",
         "fingerprint": "e124dbc2b4dbc3757b8bfab1722e8280",
         "original_path": "coalib/misc/Future.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/misc/MutableValue.py",
+        "type": "file",
+        "name": "MutableValue.py",
+        "size": 80,
+        "sha1": "4897a234c35f97cc6782289bd289f7b79962d292",
+        "fingerprint": "2ea13e761002738040a4a408074e2143",
+        "original_path": "coalib/misc/MutableValue.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/misc/StringConverter.py",
+        "type": "file",
+        "name": "StringConverter.py",
+        "size": 5054,
+        "sha1": "c631950e218cab444d1493617a65a12b00364881",
+        "fingerprint": "ea9a8d1344c48ce23d4fb5e986e50a88",
+        "original_path": "coalib/misc/StringConverter.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/output/dbus/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 561,
+        "sha1": "727f8b13d15f98f72c6dc45aaa76ce1d209a6b90",
+        "fingerprint": "13b5a7360a43dd189f681c5ea9a850ae",
+        "original_path": "coalib/output/dbus/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/output/dbus/BuildDbusService.py",
+        "type": "file",
+        "name": "BuildDbusService.py",
+        "size": 1411,
+        "sha1": "50d4a97f5b22a668fa6b32a5439d895395e35ed8",
+        "fingerprint": "f396d383c00c04c29308444c18fa4b61",
+        "original_path": "coalib/output/dbus/BuildDbusService.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/output/dbus/DbusApp.py",
+        "type": "file",
+        "name": "DbusApp.py",
+        "size": 1509,
+        "sha1": "3549f039b292fbefdf45c2c487b3695daaec594f",
+        "fingerprint": "3315270d0f17234d9838f3542645e550",
+        "original_path": "coalib/output/dbus/DbusApp.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/output/dbus/DbusDocument.py",
+        "type": "file",
+        "name": "DbusDocument.py",
+        "size": 6938,
+        "sha1": "c785c58df4bb36e11204298b08fd11706fec0537",
+        "fingerprint": "76b6e667cc3be1d65dfbb3ce78a6708b",
+        "original_path": "coalib/output/dbus/DbusDocument.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/output/dbus/DbusServer.py",
+        "type": "file",
+        "name": "DbusServer.py",
+        "size": 5769,
+        "sha1": "d16266087223a9556f6e4781e69de390068dfe06",
+        "fingerprint": "b000c2408994a39d58cfbd1d6344e536",
+        "original_path": "coalib/output/dbus/DbusServer.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/parsing/StringProcessing/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 1082,
+        "sha1": "fbd024543ce29cc0fedc6ad396a10d64a7a61128",
+        "fingerprint": "344d7f56111c282cbcde92929e63e141",
+        "original_path": "coalib/parsing/StringProcessing/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/parsing/StringProcessing/Core.py",
+        "type": "file",
+        "name": "Core.py",
+        "size": 21420,
+        "sha1": "9bc4ee2efb4030a110eee77aa93340bcc523d142",
+        "fingerprint": "43722cfbf2f6d56ca294653b1e16af80",
+        "original_path": "coalib/parsing/StringProcessing/Core.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/parsing/StringProcessing/Filters.py",
+        "type": "file",
+        "name": "Filters.py",
+        "size": 1331,
+        "sha1": "d6c829ce09c42b1f32c80427656ecc2571ba86a9",
+        "fingerprint": "a60f7b72ef38d44cb9ed9093571f9043",
+        "original_path": "coalib/parsing/StringProcessing/Filters.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/parsing/StringProcessing/InBetweenMatch.py",
+        "type": "file",
+        "name": "InBetweenMatch.py",
+        "size": 2120,
+        "sha1": "8a30603a995eb98fdb520b6ea1c8ea87be369c59",
+        "fingerprint": "24530d0b9ff122277ff62d13250ecc8b",
+        "original_path": "coalib/parsing/StringProcessing/InBetweenMatch.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/parsing/StringProcessing/Match.py",
+        "type": "file",
+        "name": "Match.py",
+        "size": 1541,
+        "sha1": "a1a68427837dd34b3bc40e4c716238da4b206efa",
+        "fingerprint": "0c2a9e5e8470895acfa04d7607158532",
+        "original_path": "coalib/parsing/StringProcessing/Match.py",
         "licenses": [],
         "copyrights": []
       }

--- a/tests/data/deltacode/sugar-coala-expected.json
+++ b/tests/data/deltacode/sugar-coala-expected.json
@@ -17,414 +17,6 @@
       "factors": [],
       "score": 100,
       "new": {
-        "path": "src/jarabe/frame/eventarea.py",
-        "type": "file",
-        "name": "eventarea.py",
-        "size": 5219,
-        "sha1": "69267915b054c03b80b6abd2dd53233948f91a59",
-        "fingerprint": "5875d786ca98e4ee12e8273076a39783",
-        "original_path": "src/jarabe/frame/eventarea.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/view/keyhandler.py",
-        "type": "file",
-        "name": "keyhandler.py",
-        "size": 8759,
-        "sha1": "2a53e8f18abc8c2162e14c7476d20b415005e3f6",
-        "fingerprint": "c8f964e48fbaef420117a1a82ef2df28",
-        "original_path": "src/jarabe/view/keyhandler.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/view/viewhelp.py",
-        "type": "file",
-        "name": "viewhelp.py",
-        "size": 12241,
-        "sha1": "512092ef1ea663f87b58ce7391fba1a8520602fc",
-        "fingerprint": "8ef1cebaa4974c78473c03f007869aa0",
-        "original_path": "src/jarabe/view/viewhelp.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/desktop/Makefile.am",
-        "type": "file",
-        "name": "Makefile.am",
-        "size": 437,
-        "sha1": "e632e2807fc7c4251a93b57d0024c5bff4b07a86",
-        "fingerprint": "f8efb1cbf61fd9e9665bbbe83e8f99c6",
-        "original_path": "src/jarabe/desktop/Makefile.am",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/frame/clipboardobject.py",
-        "type": "file",
-        "name": "clipboardobject.py",
-        "size": 4306,
-        "sha1": "065aa62c7941d394ec738298bb2c97fcc83bc90e",
-        "fingerprint": "1ae463faeedbf5ce0a806f1575e35ea8",
-        "original_path": "src/jarabe/frame/clipboardobject.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/model/desktop.py",
-        "type": "file",
-        "name": "desktop.py",
-        "size": 3714,
-        "sha1": "6e5e6de680e23ffc0bb6f4e4f714469cec0d1013",
-        "fingerprint": "d8fc4bb0829be54716a0e1a364aa8cbf",
-        "original_path": "src/jarabe/model/desktop.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/intro/window.py",
-        "type": "file",
-        "name": "window.py",
-        "size": 13552,
-        "sha1": "44197f8f07a654dcb4aaa12f9279ce50c99dbc7e",
-        "fingerprint": "5bf5cea88cabf3f26e4ec1e8e4d3ae24",
-        "original_path": "src/jarabe/intro/window.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/journal/keepicon.py",
-        "type": "file",
-        "name": "keepicon.py",
-        "size": 2441,
-        "sha1": "09e75da17325bac9c1572a7c189083c802826301",
-        "fingerprint": "f8edc3e8a68ccf672296253164abcde7",
-        "original_path": "src/jarabe/journal/keepicon.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/journal/projectview.py",
-        "type": "file",
-        "name": "projectview.py",
-        "size": 5486,
-        "sha1": "bea7d8d5de546621bf114984ca63211834858c4f",
-        "fingerprint": "dab4f7bcd0aee5fae626474077b686e4",
-        "original_path": "src/jarabe/journal/projectview.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/journal/model.py",
-        "type": "file",
-        "name": "model.py",
-        "size": 31907,
-        "sha1": "5236442a0c7816000e53c0a9abd6372dee6a7493",
-        "fingerprint": "69e145eaf4ee59977ccfac50cfa6a977",
-        "original_path": "src/jarabe/journal/model.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/journal/expandedentry.py",
-        "type": "file",
-        "name": "expandedentry.py",
-        "size": 20484,
-        "sha1": "78114bd9e62b5bc8e6be54d5d5bb8c6c48f8ea4a",
-        "fingerprint": "a804b7feddef6d24dec762d7fcaa9eaf",
-        "original_path": "src/jarabe/journal/expandedentry.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/model/update/microformat.py",
-        "type": "file",
-        "name": "microformat.py",
-        "size": 16823,
-        "sha1": "81cc0a1de95ac4c9b204d4f7e19474a46ff8c793",
-        "fingerprint": "d34578f85c07e55f2e3478aa2cc23d02",
-        "original_path": "src/jarabe/model/update/microformat.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/journal/journalwindow.py",
-        "type": "file",
-        "name": "journalwindow.py",
-        "size": 1233,
-        "sha1": "3dabb719b48b425f37adf4fda0a535e43497e5ff",
-        "fingerprint": "f8e153fa568be7622aae63a367aacea7",
-        "original_path": "src/jarabe/journal/journalwindow.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/main.py",
-        "type": "file",
-        "name": "main.py",
-        "size": 11057,
-        "sha1": "acb0dd5bf1f29a0ed57320780db4de5a550fc5a6",
-        "fingerprint": "8ee0724a5e9745d30216005a5de6839d",
-        "original_path": "src/jarabe/main.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/desktop/homebackgroundbox.py",
-        "type": "file",
-        "name": "homebackgroundbox.py",
-        "size": 3394,
-        "sha1": "b512e1f003c88cc242324253cd17f48333a73684",
-        "fingerprint": "fa39d9aad6bcc76e27a721c036b2a589",
-        "original_path": "src/jarabe/desktop/homebackgroundbox.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/controlpanel/sectionview.py",
-        "type": "file",
-        "name": "sectionview.py",
-        "size": 2734,
-        "sha1": "523a5a296e34d173069fa9f16ae5695bc0050c54",
-        "fingerprint": "acacedf21798c74e676603b464aa6985",
-        "original_path": "src/jarabe/controlpanel/sectionview.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/util/telepathy/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 731,
-        "sha1": "697c8fe6a59f7c7fe8026bba569135ebe6a1755b",
-        "fingerprint": "b8a46baaf69bc74e2aa661a064aa86a7",
-        "original_path": "src/jarabe/util/telepathy/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/view/gesturehandler.py",
-        "type": "file",
-        "name": "gesturehandler.py",
-        "size": 2473,
-        "sha1": "13ec850db86f39ff6b75a83e474b58a96ecac838",
-        "fingerprint": "daf9e8e24e9bef6e2aa661f265bf9684",
-        "original_path": "src/jarabe/view/gesturehandler.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/model/screenshot.py",
-        "type": "file",
-        "name": "screenshot.py",
-        "size": 3989,
-        "sha1": "fa06fba647be031477b743088dbfb0be9abe669f",
-        "fingerprint": "d82167a274fb85cda2ae899076e2a4ec",
-        "original_path": "src/jarabe/model/screenshot.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/journal/journalactivity.py",
-        "type": "file",
-        "name": "journalactivity.py",
-        "size": 23977,
-        "sha1": "2284fd2226629da274c505cc20273d35ecc30e4c",
-        "fingerprint": "cc69fa14a733fe8f5677273a27ba9177",
-        "original_path": "src/jarabe/journal/journalactivity.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/controlpanel/toolbar.py",
-        "type": "file",
-        "name": "toolbar.py",
-        "size": 5055,
-        "sha1": "c9ce20b9b87560f847add97a3450eb7389449dfe",
-        "fingerprint": "ce756fe8ac9dc47b32a4a3e166b302b1",
-        "original_path": "src/jarabe/controlpanel/toolbar.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/desktop/snowflakelayout.py",
-        "type": "file",
-        "name": "snowflakelayout.py",
-        "size": 4462,
-        "sha1": "1dfebdc586bea6d8abb2d8d2c287453242deb241",
-        "fingerprint": "18e1e3cac0a9aeef3006f9b3650a15b9",
-        "original_path": "src/jarabe/desktop/snowflakelayout.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/view/viewhelp_webkit2.py",
-        "type": "file",
-        "name": "viewhelp_webkit2.py",
-        "size": 3617,
-        "sha1": "365a64c1e255e85a74e8fed2d7303fed7c2ea81e",
-        "fingerprint": "7c60cfe2de9bc5ceea2621716fa4a786",
-        "original_path": "src/jarabe/view/viewhelp_webkit2.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/journal/iconmodel.py",
-        "type": "file",
-        "name": "iconmodel.py",
-        "size": 4390,
-        "sha1": "bad5e8adb2e987dc63e1e8240ab43d037d16e1fd",
-        "fingerprint": "b9e17d60c29bcd5e1eb443b56de68ea6",
-        "original_path": "src/jarabe/journal/iconmodel.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
         "path": "src/Makefile.am",
         "type": "file",
         "name": "Makefile.am",
@@ -432,1349 +24,6 @@
         "sha1": "1a9027f84abc0055fda6cc841b7ffd5a359d4648",
         "fingerprint": "c653799a1f4f8ea719a58981dcc9901f",
         "original_path": "src/Makefile.am",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/view/palettes.py",
-        "type": "file",
-        "name": "palettes.py",
-        "size": 11628,
-        "sha1": "e2a5f5655204ecb2f698f0b56b6e081b1bf37e64",
-        "fingerprint": "f33dd923ffeec4ee38b4264f3fc709a1",
-        "original_path": "src/jarabe/view/palettes.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/controlpanel/Makefile.am",
-        "type": "file",
-        "name": "Makefile.am",
-        "size": 162,
-        "sha1": "3204e0c969f3329bd331b3a05082e3823d54878b",
-        "fingerprint": "470d1dae26d3d2a377570f06ce37eccf",
-        "original_path": "src/jarabe/controlpanel/Makefile.am",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/webservice/Makefile.am",
-        "type": "file",
-        "name": "Makefile.am",
-        "size": 112,
-        "sha1": "218824a95b6065b00ce5f275f37696d5c03e61c4",
-        "fingerprint": "2385043ee21bd23d592558160cd5b38a",
-        "original_path": "src/jarabe/webservice/Makefile.am",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/view/buddymenu.py",
-        "type": "file",
-        "name": "buddymenu.py",
-        "size": 8681,
-        "sha1": "0c3d6b444da40574cd7f225f491221efaaaf1bbd",
-        "fingerprint": "8bed778ac79905421bb4e19464a7af2e",
-        "original_path": "src/jarabe/view/buddymenu.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/journal/iconview.py",
-        "type": "file",
-        "name": "iconview.py",
-        "size": 12200,
-        "sha1": "ebb020d948913f74ef89c9870e4d0770d192bd22",
-        "fingerprint": "f27087ffc70be4c251f7f5f4f6a29f84",
-        "original_path": "src/jarabe/journal/iconview.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/model/keyboard.py",
-        "type": "file",
-        "name": "keyboard.py",
-        "size": 2222,
-        "sha1": "de63e99ccdc829360439d9d6becb897affa63926",
-        "fingerprint": "72f12e68429bc70e0ab263a264e296e5",
-        "original_path": "src/jarabe/model/keyboard.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/webservice/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 0,
-        "sha1": null,
-        "fingerprint": null,
-        "original_path": "src/jarabe/webservice/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/frame/activitiestray.py",
-        "type": "file",
-        "name": "activitiestray.py",
-        "size": 33360,
-        "sha1": "da32c81d8eec6b9a336a8fbacf336a60b8a952ec",
-        "fingerprint": "9a85cfaac4bbbbdd5f1da0e4ffbf5f24",
-        "original_path": "src/jarabe/frame/activitiestray.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/view/alerts.py",
-        "type": "file",
-        "name": "alerts.py",
-        "size": 2055,
-        "sha1": "0b2eaa6e3c6646cf685089827f2857fe55c6710e",
-        "fingerprint": "fa6cecf2c69fc442223423846da2c6a4",
-        "original_path": "src/jarabe/view/alerts.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/journal/palettes.py",
-        "type": "file",
-        "name": "palettes.py",
-        "size": 25982,
-        "sha1": "aa59464762ed97b59c8eb9c89b4eb5ce801b7f24",
-        "fingerprint": "f87dfff26a1fc49a9617c65f44ab0760",
-        "original_path": "src/jarabe/journal/palettes.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/journal/Makefile.am",
-        "type": "file",
-        "name": "Makefile.am",
-        "size": 441,
-        "sha1": "a3246b60d3d0e49b37105860e410090213dcc31e",
-        "fingerprint": "09aa919c04b58a9dd720123b769b5cee",
-        "original_path": "src/jarabe/journal/Makefile.am",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/journal/listview.py",
-        "type": "file",
-        "name": "listview.py",
-        "size": 34423,
-        "sha1": "75b45749051d348c33d45fb46874dc707e8389a7",
-        "fingerprint": "dec4d4da9d7aff6004e32ef632efc5b0",
-        "original_path": "src/jarabe/journal/listview.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/desktop/schoolserver.py",
-        "type": "file",
-        "name": "schoolserver.py",
-        "size": 5472,
-        "sha1": "744dbe2ebd7def253cb6d0b0fe707b7485005687",
-        "fingerprint": "32b09ba8c68fc7c6ca0267d3259083f0",
-        "original_path": "src/jarabe/desktop/schoolserver.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/util/telepathy/Makefile.am",
-        "type": "file",
-        "name": "Makefile.am",
-        "size": 111,
-        "sha1": "162644a57f08fea633dec414d02981394143cfc0",
-        "fingerprint": "e15d522ebcd3f8b1cc6e43ca1a97fe5e",
-        "original_path": "src/jarabe/util/telepathy/Makefile.am",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/model/update/updater.py",
-        "type": "file",
-        "name": "updater.py",
-        "size": 10563,
-        "sha1": "88f7186ef2cedb170f3522ffc3a80df673dd2c1e",
-        "fingerprint": "b869e7e9c588ca5a6094c8f32d83def1",
-        "original_path": "src/jarabe/model/update/updater.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/model/buddy.py",
-        "type": "file",
-        "name": "buddy.py",
-        "size": 6429,
-        "sha1": "0c75cf0f14fa2ba57b795068984c031ff722365d",
-        "fingerprint": "b420c7e8f6cf065239e4f281642af5ab",
-        "original_path": "src/jarabe/model/buddy.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/view/buddyicon.py",
-        "type": "file",
-        "name": "buddyicon.py",
-        "size": 2754,
-        "sha1": "1b2f5913b20b3969285e0541f65e276e5d262db5",
-        "fingerprint": "baf4f3a2168be5c62a3760f166a2c6a8",
-        "original_path": "src/jarabe/view/buddyicon.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/model/update/aslo.py",
-        "type": "file",
-        "name": "aslo.py",
-        "size": 6700,
-        "sha1": "65a1f059015d567a7be1597ce2eb388cfd4687ff",
-        "fingerprint": "10b1fea46393c18a2cace0b2c6aa24e1",
-        "original_path": "src/jarabe/model/update/aslo.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/model/mimeregistry.py",
-        "type": "file",
-        "name": "mimeregistry.py",
-        "size": 1565,
-        "sha1": "5a28013a857907f3b0411500746823731b6e8745",
-        "fingerprint": "b8f1efa0e69bc54e282661b124aa86a3",
-        "original_path": "src/jarabe/model/mimeregistry.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/util/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 721,
-        "sha1": "07d09709f3b7e592087c1e75996f1c6eb2bb33b9",
-        "fingerprint": "b8e4ebaaf68bc74e2aa660a164aa86a4",
-        "original_path": "src/jarabe/util/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/webservice/account.py",
-        "type": "file",
-        "name": "account.py",
-        "size": 3590,
-        "sha1": "b575677957524c07b40d7e0199ce2b96e91dee20",
-        "fingerprint": "a0f558b0561fdf0f796441f320bb9ac5",
-        "original_path": "src/jarabe/webservice/account.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/journal/misc.py",
-        "type": "file",
-        "name": "misc.py",
-        "size": 14885,
-        "sha1": "d1620f6615148644793ff1162048363acf069c15",
-        "fingerprint": "8be4c3189894821ea7c7eb1e75da7698",
-        "original_path": "src/jarabe/journal/misc.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/view/customizebundle.py",
-        "type": "file",
-        "name": "customizebundle.py",
-        "size": 7423,
-        "sha1": "18b063de275c737138412143a655a67f6b4bb4f2",
-        "fingerprint": "97f0c7a316536fdc6a0c60321cc585a0",
-        "original_path": "src/jarabe/view/customizebundle.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/intro/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 474,
-        "sha1": "67ba25be5bb63ac8ecb5cfe6792810169a3e350c",
-        "fingerprint": "038129d0f91caf523d4b9262bdd5f1f8",
-        "original_path": "src/jarabe/intro/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/model/telepathyclient.py",
-        "type": "file",
-        "name": "telepathyclient.py",
-        "size": 5202,
-        "sha1": "0b0d1500ca8a16f4a2d5edb9794568c9fd1b9953",
-        "fingerprint": "7e24fbac6289e746202ee72c6482f3c4",
-        "original_path": "src/jarabe/model/telepathyclient.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/controlpanel/cmd.py",
-        "type": "file",
-        "name": "cmd.py",
-        "size": 6014,
-        "sha1": "7e819114b8b6489557fd381031480da62f9e88bb",
-        "fingerprint": "f86407aa628ba74af83728f1268a8664",
-        "original_path": "src/jarabe/controlpanel/cmd.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/model/update/Makefile.am",
-        "type": "file",
-        "name": "Makefile.am",
-        "size": 119,
-        "sha1": "93c092ca71a9f768ef2eaa4d8815360224f5a353",
-        "fingerprint": "4248972bae13126039d63242aafc4aac",
-        "original_path": "src/jarabe/model/update/Makefile.am",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/model/network.py",
-        "type": "file",
-        "name": "network.py",
-        "size": 41904,
-        "sha1": "8ef19f55176aa33f73880394c4009fde5b2d3b57",
-        "fingerprint": "9e5452327e9c8359a2c20b8d47f75cb1",
-        "original_path": "src/jarabe/model/network.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/util/Makefile.am",
-        "type": "file",
-        "name": "Makefile.am",
-        "size": 171,
-        "sha1": "a36379897330ced7a918be9f4d1fe5bb0918725a",
-        "fingerprint": "6dcf43a2c3955a09e9df292bdb88bbec",
-        "original_path": "src/jarabe/util/Makefile.am",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/desktop/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 677,
-        "sha1": "88162a20ff790a3197b028a0b4944e2132af17a0",
-        "fingerprint": "d8e4ebaad68be74e6a2661b164a2a6a7",
-        "original_path": "src/jarabe/desktop/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/desktop/groupbox.py",
-        "type": "file",
-        "name": "groupbox.py",
-        "size": 2812,
-        "sha1": "d90d36b79e75bd89bdcca9a2719ffbecbc79c4b3",
-        "fingerprint": "baf4ffb8668be7462a76a00266e2c6ac",
-        "original_path": "src/jarabe/desktop/groupbox.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/desktop/keydialog.py",
-        "type": "file",
-        "name": "keydialog.py",
-        "size": 10316,
-        "sha1": "bd48e8beaf21fa239668ef718b38163976d05624",
-        "fingerprint": "b8d69bfee48b588743064db6e5909f46",
-        "original_path": "src/jarabe/desktop/keydialog.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/util/downloader.py",
-        "type": "file",
-        "name": "downloader.py",
-        "size": 8616,
-        "sha1": "471dfa347b25cb2b5e62b117db22c9fa9227ae93",
-        "fingerprint": "d99c45a45e8b67472707a1bd76a65d53",
-        "original_path": "src/jarabe/util/downloader.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/frame/friendstray.py",
-        "type": "file",
-        "name": "friendstray.py",
-        "size": 4312,
-        "sha1": "7593e936cb4f2bf700cd1f03af4455a0ac605728",
-        "fingerprint": "3eb0cd6a669fc7526b3ec9a46fdb878c",
-        "original_path": "src/jarabe/frame/friendstray.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/model/friends.py",
-        "type": "file",
-        "name": "friends.py",
-        "size": 5278,
-        "sha1": "f9786839cecc0a9e157144c6759b5e72aa5446dd",
-        "fingerprint": "1fa4e37a568b27502626673524f2d2aa",
-        "original_path": "src/jarabe/model/friends.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/desktop/transitionbox.py",
-        "type": "file",
-        "name": "transitionbox.py",
-        "size": 2383,
-        "sha1": "8a54936c44ca93176305a2af2e15e0241e63c750",
-        "fingerprint": "dabcffb82e9be7466aa4223367a29626",
-        "original_path": "src/jarabe/desktop/transitionbox.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/journal/detailview.py",
-        "type": "file",
-        "name": "detailview.py",
-        "size": 3968,
-        "sha1": "643e92e4f62b520668ee3e511d8ce9e8bd5ca422",
-        "fingerprint": "faf169b2ee89e4ed463665f564e6e6a4",
-        "original_path": "src/jarabe/journal/detailview.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/model/notifications.py",
-        "type": "file",
-        "name": "notifications.py",
-        "size": 4491,
-        "sha1": "8ec982bd679849d365d9332578771d68fd73ece2",
-        "fingerprint": "b974e028e689846232a621e36caaa6af",
-        "original_path": "src/jarabe/model/notifications.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/testrunner.py",
-        "type": "file",
-        "name": "testrunner.py",
-        "size": 1607,
-        "sha1": "d51cc4701b3b3c94720264a0a8063e5bccd98b5b",
-        "fingerprint": "ba70dda0e69bc50a2aa661a164a2d4a5",
-        "original_path": "src/jarabe/testrunner.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/model/shell.py",
-        "type": "file",
-        "name": "shell.py",
-        "size": 28024,
-        "sha1": "abee773ffbe9f67244e387abf2fe89c932b25710",
-        "fingerprint": "17adf56bb57e6ec6604a696cd4f790be",
-        "original_path": "src/jarabe/model/shell.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/view/viewhelp_webkit1.py",
-        "type": "file",
-        "name": "viewhelp_webkit1.py",
-        "size": 4473,
-        "sha1": "9bddebeae693d2bac8ea53c3cc038d99576cd3b7",
-        "fingerprint": "38e4cfea8290657e62a6213167a78525",
-        "original_path": "src/jarabe/view/viewhelp_webkit1.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/frame/clipboardpanelwindow.py",
-        "type": "file",
-        "name": "clipboardpanelwindow.py",
-        "size": 5155,
-        "sha1": "10e2162f45cc8b98449c3c48d7b9c4afc9f717bf",
-        "fingerprint": "e9b8cbd8c21fe4ea2c86e9f464a7cca9",
-        "original_path": "src/jarabe/frame/clipboardpanelwindow.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/desktop/homebox.py",
-        "type": "file",
-        "name": "homebox.py",
-        "size": 7912,
-        "sha1": "8dfcf52ac281cabd6c12e81b373ade4e6e5cfde9",
-        "fingerprint": "1860dfb806ce8729a80766e2678ec33f",
-        "original_path": "src/jarabe/desktop/homebox.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/frame/clipboardicon.py",
-        "type": "file",
-        "name": "clipboardicon.py",
-        "size": 8071,
-        "sha1": "15bec0855aedb3f09d6e086257baed0e156c8079",
-        "fingerprint": "fee543aa01bac572ea6681347ebde685",
-        "original_path": "src/jarabe/frame/clipboardicon.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/desktop/favoritesview.py",
-        "type": "file",
-        "name": "favoritesview.py",
-        "size": 27752,
-        "sha1": "9b50630db1f7b831a6fe77a17c767a70683e487e",
-        "fingerprint": "dbb562ba89d6f6f69ae3a3a455ef8470",
-        "original_path": "src/jarabe/desktop/favoritesview.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/util/telepathy/connection_watcher.py",
-        "type": "file",
-        "name": "connection_watcher.py",
-        "size": 4033,
-        "sha1": "1e8b9a73e21ea2daddcbe9dc125693cba96111b6",
-        "fingerprint": "5eedebfa5e594f4e02a6031126c8e6bd",
-        "original_path": "src/jarabe/util/telepathy/connection_watcher.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/frame/clipboard.py",
-        "type": "file",
-        "name": "clipboard.py",
-        "size": 6200,
-        "sha1": "96d7a152bf308551465e00648a5b8d3f76cc4c77",
-        "fingerprint": "ede17a7ad25bc7ee21a633d67583b7a5",
-        "original_path": "src/jarabe/frame/clipboard.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/model/invites.py",
-        "type": "file",
-        "name": "invites.py",
-        "size": 12064,
-        "sha1": "ce63d660616cfb35a20538428cef8ea2c858e6d8",
-        "fingerprint": "93ec6388de1ffc6a12e4e73a74e39a0d",
-        "original_path": "src/jarabe/model/invites.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/model/brightness.py",
-        "type": "file",
-        "name": "brightness.py",
-        "size": 4879,
-        "sha1": "184b2822b3f35a423688307009791037e4865c6d",
-        "fingerprint": "cce4cfe48711e76f2a36228261aa8689",
-        "original_path": "src/jarabe/model/brightness.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/model/adhoc.py",
-        "type": "file",
-        "name": "adhoc.py",
-        "size": 11641,
-        "sha1": "430dc30d4a5a3ad7dee541f4e592e13355f680b1",
-        "fingerprint": "ea8247aa065c4cfe0aee07b566c184e9",
-        "original_path": "src/jarabe/model/adhoc.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/model/Makefile.am",
-        "type": "file",
-        "name": "Makefile.am",
-        "size": 473,
-        "sha1": "4a400df1a95aaa822319795b663e460e5efe1e82",
-        "fingerprint": "e09d81380a6b02430a637947fc22f580",
-        "original_path": "src/jarabe/model/Makefile.am",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/journal/volumestoolbar.py",
-        "type": "file",
-        "name": "volumestoolbar.py",
-        "size": 13220,
-        "sha1": "1bb400584046ea2a5f1bd725174754c1b494ac4e",
-        "fingerprint": "18c8e22ad09fc09a38bc24302c2e2626",
-        "original_path": "src/jarabe/journal/volumestoolbar.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/frame/devicestray.py",
-        "type": "file",
-        "name": "devicestray.py",
-        "size": 1901,
-        "sha1": "dd7f3ed92f4622cbfe39d7b53264c9fe47a41bf7",
-        "fingerprint": "90a553b8669bc7de2e3668c165b2862c",
-        "original_path": "src/jarabe/frame/devicestray.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/intro/Makefile.am",
-        "type": "file",
-        "name": "Makefile.am",
-        "size": 135,
-        "sha1": "b1ac2f68b8959a36fdf1fd7ebdc432bbe4d89238",
-        "fingerprint": "498defa166d35abd41bd01088edcba0e",
-        "original_path": "src/jarabe/intro/Makefile.am",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/journal/modalalert.py",
-        "type": "file",
-        "name": "modalalert.py",
-        "size": 3640,
-        "sha1": "3bbd3bad617dd3e974b67cf0cba82fa7af53a0db",
-        "fingerprint": "c8e067aa0e9bef8e28dc688165fa47a4",
-        "original_path": "src/jarabe/journal/modalalert.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/journal/journaltoolbox.py",
-        "type": "file",
-        "name": "journaltoolbox.py",
-        "size": 41932,
-        "sha1": "6d98aae400376ca1bef29ba81c59a2eec39d1d8d",
-        "fingerprint": "f8144375e499ddbefa18a6537f8e5ca1",
-        "original_path": "src/jarabe/journal/journaltoolbox.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/view/service.py",
-        "type": "file",
-        "name": "service.py",
-        "size": 3237,
-        "sha1": "b6ec741d8b3a269dd9db610635fdc75d3a988bc4",
-        "fingerprint": "f2eccbd4eebbcf41222661d064ea9eb6",
-        "original_path": "src/jarabe/view/service.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/desktop/homewindow.py",
-        "type": "file",
-        "name": "homewindow.py",
-        "size": 11105,
-        "sha1": "4b14c3cb7ebf2d6e464462eadc9759eca13dee33",
-        "fingerprint": "74596fae4418ceac8a922aa17d3a92a4",
-        "original_path": "src/jarabe/desktop/homewindow.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/model/session.py",
-        "type": "file",
-        "name": "session.py",
-        "size": 4553,
-        "sha1": "37be5fc32cb5a41cb0a487b6838031cc71cdbb22",
-        "fingerprint": "fea17fb0d29de5562286a15064b214e5",
-        "original_path": "src/jarabe/model/session.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/journal/bundlelauncher.py",
-        "type": "file",
-        "name": "bundlelauncher.py",
-        "size": 2640,
-        "sha1": "cc87b31149094cefb0e6728233068938605fa9d8",
-        "fingerprint": "38ede9a2ae1b67560fa2e0a07ccb8e26",
-        "original_path": "src/jarabe/journal/bundlelauncher.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/model/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 677,
-        "sha1": "88162a20ff790a3197b028a0b4944e2132af17a0",
-        "fingerprint": "d8e4ebaad68be74e6a2661b164a2a6a7",
-        "original_path": "src/jarabe/model/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/frame/clipboardmenu.py",
-        "type": "file",
-        "name": "clipboardmenu.py",
-        "size": 8708,
-        "sha1": "5f251a2676833eb3b16bd89ef8bddd98cbbd868e",
-        "fingerprint": "1af27da8c69bc4780ee064a92dba8bb2",
-        "original_path": "src/jarabe/frame/clipboardmenu.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/frame/framewindow.py",
-        "type": "file",
-        "name": "framewindow.py",
-        "size": 5682,
-        "sha1": "8a2e6df614352baf241093e664ad8c77868a3428",
-        "fingerprint": "51b5eb6395897cb26aacb58024c59ef5",
-        "original_path": "src/jarabe/frame/framewindow.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/model/filetransfer.py",
-        "type": "file",
-        "name": "filetransfer.py",
-        "size": 13272,
-        "sha1": "6cc15e7c200ad96067fc34496f1edfcfe190a55d",
-        "fingerprint": "980d63a2ec8b55cb3296b0fc70bfde1e",
-        "original_path": "src/jarabe/model/filetransfer.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/webservice/accountsmanager.py",
-        "type": "file",
-        "name": "accountsmanager.py",
-        "size": 7106,
-        "sha1": "c2ec06ae0baf6a4bddec6c72fc7838ef64753c4e",
-        "fingerprint": "b4e577ea824bf3c662640de12d1ff585",
-        "original_path": "src/jarabe/webservice/accountsmanager.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/controlpanel/inlinealert.py",
-        "type": "file",
-        "name": "inlinealert.py",
-        "size": 2747,
-        "sha1": "9f257dd39c9d07dfb6ed33f785e9a30183da54c0",
-        "fingerprint": "58fceeaa56cee7de0aa4e1206d8a07a5",
-        "original_path": "src/jarabe/controlpanel/inlinealert.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/view/cursortracker.py",
-        "type": "file",
-        "name": "cursortracker.py",
-        "size": 1728,
-        "sha1": "c7d296d7ea47181cb8d1a86ba6aa45e435d24e31",
-        "fingerprint": "5aaceeeac68b8d4a2a1461e266b38b60",
-        "original_path": "src/jarabe/view/cursortracker.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/view/tabbinghandler.py",
-        "type": "file",
-        "name": "tabbinghandler.py",
-        "size": 6108,
-        "sha1": "00a4e0149fa078d24965bce5b0811c64b9331655",
-        "fingerprint": "522345b05ab98d1622caa5936cbac5e4",
-        "original_path": "src/jarabe/view/tabbinghandler.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/desktop/meshbox.py",
-        "type": "file",
-        "name": "meshbox.py",
-        "size": 23764,
-        "sha1": "d158fc1b4e164dc23154b332dd1c709b73f89419",
-        "fingerprint": "9ae87faa5efdde322790ab107eb0fca0",
-        "original_path": "src/jarabe/desktop/meshbox.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/model/speech.py",
-        "type": "file",
-        "name": "speech.py",
-        "size": 978,
-        "sha1": "bdf05ff03a07aca5d0de3ee05eedd51f0f6af240",
-        "fingerprint": "b8e5efaac69ac74e6a2660a364aa8ea4",
-        "original_path": "src/jarabe/model/speech.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/util/httprange.py",
-        "type": "file",
-        "name": "httprange.py",
-        "size": 2746,
-        "sha1": "ab9c70e9dd660062a8e4463c79edd097e072e9fe",
-        "fingerprint": "9ce03ff2f21bf7624ab461b1648686b2",
-        "original_path": "src/jarabe/util/httprange.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/frame/notification.py",
-        "type": "file",
-        "name": "notification.py",
-        "size": 10970,
-        "sha1": "ca9dda15ae0bfeb14e5a9d90512bd03da93d6d61",
-        "fingerprint": "53f46d726e1807ef2ac7a0c06eaa8da4",
-        "original_path": "src/jarabe/frame/notification.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/journal/listmodel.py",
-        "type": "file",
-        "name": "listmodel.py",
-        "size": 10533,
-        "sha1": "a69cd4db6163fed3c64534772c50bba72ef88718",
-        "fingerprint": "dc85a9b2c65bc12216d4237d45ce2ef1",
-        "original_path": "src/jarabe/journal/listmodel.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/view/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 677,
-        "sha1": "88162a20ff790a3197b028a0b4944e2132af17a0",
-        "fingerprint": "d8e4ebaad68be74e6a2661b164a2a6a7",
-        "original_path": "src/jarabe/view/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/desktop/favoriteslayout.py",
-        "type": "file",
-        "name": "favoriteslayout.py",
-        "size": 24400,
-        "sha1": "2d778d406c92fe26808240435d10d19dd9d07cc3",
-        "fingerprint": "53300d9ce0d3c414ca06a9b9f6a5ed21",
-        "original_path": "src/jarabe/desktop/favoriteslayout.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/apisocket.py",
-        "type": "file",
-        "name": "apisocket.py",
-        "size": 11107,
-        "sha1": "8faf6730bf19147f9703698180d026c85ccbd76d",
-        "fingerprint": "f43d45ea1d83d2ca3aad2fad35b180c9",
-        "original_path": "src/jarabe/apisocket.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/desktop/viewtoolbar.py",
-        "type": "file",
-        "name": "viewtoolbar.py",
-        "size": 9491,
-        "sha1": "75dab51b0dd3e14ccf9f61081a8b0ee11ef8464b",
-        "fingerprint": "925ce6facbafa54f60a421b30632938e",
-        "original_path": "src/jarabe/desktop/viewtoolbar.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/frame/frame.py",
-        "type": "file",
-        "name": "frame.py",
-        "size": 9104,
-        "sha1": "9cc8e66b79bab8c1bf8887aee00cbbeb4e57f1c0",
-        "fingerprint": "dea965fafbdb065a4ec6234524339942",
-        "original_path": "src/jarabe/frame/frame.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/model/sound.py",
-        "type": "file",
-        "name": "sound.py",
-        "size": 2736,
-        "sha1": "a5f1580f934949f7fe8911d2c72bf4dd41d189d6",
-        "fingerprint": "aa7cebecee8a45cf49a609d465a29eb1",
-        "original_path": "src/jarabe/model/sound.py",
         "licenses": [],
         "copyrights": []
       },
@@ -1802,370 +51,13 @@
       "factors": [],
       "score": 100,
       "new": {
-        "path": "src/jarabe/frame/Makefile.am",
+        "path": "src/jarabe/apisocket.py",
         "type": "file",
-        "name": "Makefile.am",
-        "size": 385,
-        "sha1": "74c53cec5699857241e3f788cfa06480921ffe5e",
-        "fingerprint": "e19d1fee02feaf2842ed128eaf27b46c",
-        "original_path": "src/jarabe/frame/Makefile.am",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/intro/genderpicker.py",
-        "type": "file",
-        "name": "genderpicker.py",
-        "size": 3248,
-        "sha1": "36f2abb02cfe7c81e38f890a72fa1b0a9769c777",
-        "fingerprint": "12f9ea2a8ecf4d566626a13277cae5a2",
-        "original_path": "src/jarabe/intro/genderpicker.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/view/launcher.py",
-        "type": "file",
-        "name": "launcher.py",
-        "size": 6044,
-        "sha1": "9b7f24c52515bd673bc2fe86be47460107e26c9f",
-        "fingerprint": "baf5d3ea1a8a7e9e23a5e3a067b2aa18",
-        "original_path": "src/jarabe/view/launcher.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/model/neighborhood.py",
-        "type": "file",
-        "name": "neighborhood.py",
-        "size": 45220,
-        "sha1": "f9c90d3d014a1cb56604918655da5b094356e3be",
-        "fingerprint": "ba3c419c8f8893d22943f61666bbe70c",
-        "original_path": "src/jarabe/model/neighborhood.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/frame/clipboardtray.py",
-        "type": "file",
-        "name": "clipboardtray.py",
-        "size": 7144,
-        "sha1": "dd1df8471c474c66a59c809c1e6b3daa9bf16680",
-        "fingerprint": "0efcc0ad5402ec5e4aac21d565ebdc62",
-        "original_path": "src/jarabe/frame/clipboardtray.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/journal/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 679,
-        "sha1": "50ce8a11c2554f374c990b85a58df27570ae33d2",
-        "fingerprint": "b8a4ebaac69bc74e2aa661a164a28ea6",
-        "original_path": "src/jarabe/journal/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/Makefile.am",
-        "type": "file",
-        "name": "Makefile.am",
-        "size": 256,
-        "sha1": "1f1e3a9c93d38ab38a4d7035a8b40b7aa37572bc",
-        "fingerprint": "24899eebc22218108997aebf9a1937ae",
-        "original_path": "src/jarabe/Makefile.am",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/frame/zoomtoolbar.py",
-        "type": "file",
-        "name": "zoomtoolbar.py",
-        "size": 4196,
-        "sha1": "3dee09e0c6a0d8da0d6496a9590f11c1c2418c54",
-        "fingerprint": "717cfbf01a992bd724b620a464839f6f",
-        "original_path": "src/jarabe/frame/zoomtoolbar.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/frame/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 824,
-        "sha1": "6d7fc42ca9b90ecb1c1f5d573a3c297bccfcd9e6",
-        "fingerprint": "d8e4feead68be7466aa460b264a2a6a7",
-        "original_path": "src/jarabe/frame/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/desktop/viewcontainer.py",
-        "type": "file",
-        "name": "viewcontainer.py",
-        "size": 2821,
-        "sha1": "6e1ac1cf4f2bf578aa692873e5388ecfe3fa21f8",
-        "fingerprint": "b869c922c28b678e0aa4612365e2b683",
-        "original_path": "src/jarabe/desktop/viewcontainer.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/frame/frameinvoker.py",
-        "type": "file",
-        "name": "frameinvoker.py",
-        "size": 1345,
-        "sha1": "e50e54888219a980e6d67b529354f072a3ccfbe0",
-        "fingerprint": "9ae4d9a2c69bc7ce26a6e5f024e28ea4",
-        "original_path": "src/jarabe/frame/frameinvoker.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/controlpanel/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 677,
-        "sha1": "88162a20ff790a3197b028a0b4944e2132af17a0",
-        "fingerprint": "d8e4ebaad68be74e6a2661b164a2a6a7",
-        "original_path": "src/jarabe/controlpanel/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/journal/journalentrybundle.py",
-        "type": "file",
-        "name": "journalentrybundle.py",
-        "size": 3135,
-        "sha1": "72c4b3ef83ae724b244aaa224f7474feca27f3b9",
-        "fingerprint": "3ef4f1eb868bc5ec6aa669a36cb997a6",
-        "original_path": "src/jarabe/journal/journalentrybundle.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/desktop/grid.py",
-        "type": "file",
-        "name": "grid.py",
-        "size": 7590,
-        "sha1": "8e7b06ca5d80a10ac1e7804dc2634756ce5002a6",
-        "fingerprint": "32e47634ea9ecf3ea966a42576ae33a2",
-        "original_path": "src/jarabe/desktop/grid.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/view/viewsource.py",
-        "type": "file",
-        "name": "viewsource.py",
-        "size": 30015,
-        "sha1": "9a740f4382b41b44b2f48dd7270852edce564cfb",
-        "fingerprint": "d4c74bfc9ab8cddff27f6ae352f2168e",
-        "original_path": "src/jarabe/view/viewsource.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/model/bundleregistry.py",
-        "type": "file",
-        "name": "bundleregistry.py",
-        "size": 27763,
-        "sha1": "3eb3a117cc6cad760d1f78a27dfbbfed09af03b6",
-        "fingerprint": "db2867bc927d405211cb023a44822866",
-        "original_path": "src/jarabe/model/bundleregistry.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/controlpanel/gui.py",
-        "type": "file",
-        "name": "gui.py",
-        "size": 21442,
-        "sha1": "2ea8bdac215993ff0c146aa4f3640e0dfeefc1f6",
-        "fingerprint": "81206db29edf01b08abeea606d8fb6c2",
-        "original_path": "src/jarabe/controlpanel/gui.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/model/screen.py",
-        "type": "file",
-        "name": "screen.py",
-        "size": 1428,
-        "sha1": "eec7eca4b12a59b85794cf1c6886e0470d23aa9d",
-        "fingerprint": "3ae5e3aa969bc7426a2461a165a2d7a7",
-        "original_path": "src/jarabe/model/screen.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/model/olpcmesh.py",
-        "type": "file",
-        "name": "olpcmesh.py",
-        "size": 9357,
-        "sha1": "74ca9a108ec1e8a26e4151eb9035e73159becb13",
-        "fingerprint": "acb078ecd799d5603eb225e726fba4a2",
-        "original_path": "src/jarabe/model/olpcmesh.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/view/Makefile.am",
-        "type": "file",
-        "name": "Makefile.am",
-        "size": 382,
-        "sha1": "1f7576f59fb572e878262fe71a7859f50020fc3f",
-        "fingerprint": "c53a72962eb0f3a1ac0fb2f40bbdc9ae",
-        "original_path": "src/jarabe/view/Makefile.am",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/desktop/activitychooser.py",
-        "type": "file",
-        "name": "activitychooser.py",
-        "size": 11858,
-        "sha1": "86bb0568a05c34643023dea6a69cb25074d58a8d",
-        "fingerprint": "42f06af2c2d4ca1ab49620c2275ade8c",
-        "original_path": "src/jarabe/desktop/activitychooser.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": null
-    },
-    {
-      "status": "added",
-      "factors": [],
-      "score": 100,
-      "new": {
-        "path": "src/jarabe/model/update/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 1074,
-        "sha1": "c50ba895727228ef71828191606b24d8ec906646",
-        "fingerprint": "d864e2ae469bc7ca2a2663b164aba7a4",
-        "original_path": "src/jarabe/model/update/__init__.py",
+        "name": "apisocket.py",
+        "size": 11107,
+        "sha1": "8faf6730bf19147f9703698180d026c85ccbd76d",
+        "fingerprint": "f43d45ea1d83d2ca3aad2fad35b180c9",
+        "original_path": "src/jarabe/apisocket.py",
         "licenses": [],
         "copyrights": []
       },
@@ -2193,13 +85,13 @@
       "factors": [],
       "score": 100,
       "new": {
-        "path": "src/jarabe/desktop/friendview.py",
+        "path": "src/jarabe/main.py",
         "type": "file",
-        "name": "friendview.py",
-        "size": 3275,
-        "sha1": "a878a31b24930bdc72240325648b137e4ceec822",
-        "fingerprint": "bcf8d1a6de89d6c34226e8b074e0b726",
-        "original_path": "src/jarabe/desktop/friendview.py",
+        "name": "main.py",
+        "size": 11057,
+        "sha1": "acb0dd5bf1f29a0ed57320780db4de5a550fc5a6",
+        "fingerprint": "8ee0724a5e9745d30216005a5de6839d",
+        "original_path": "src/jarabe/main.py",
         "licenses": [],
         "copyrights": []
       },
@@ -2210,13 +102,13 @@
       "factors": [],
       "score": 100,
       "new": {
-        "path": "src/jarabe/journal/objectchooser.py",
+        "path": "src/jarabe/Makefile.am",
         "type": "file",
-        "name": "objectchooser.py",
-        "size": 8575,
-        "sha1": "667d588181c3ac7bf74f90b66620ac28ddce213f",
-        "fingerprint": "5e20ebbeeecd6fcd664221166404e782",
-        "original_path": "src/jarabe/journal/objectchooser.py",
+        "name": "Makefile.am",
+        "size": 256,
+        "sha1": "1f1e3a9c93d38ab38a4d7035a8b40b7aa37572bc",
+        "fingerprint": "24899eebc22218108997aebf9a1937ae",
+        "original_path": "src/jarabe/Makefile.am",
         "licenses": [],
         "copyrights": []
       },
@@ -2227,13 +119,149 @@
       "factors": [],
       "score": 100,
       "new": {
-        "path": "src/jarabe/desktop/networkviews.py",
+        "path": "src/jarabe/testrunner.py",
         "type": "file",
-        "name": "networkviews.py",
-        "size": 30613,
-        "sha1": "f292cdfb976fa12d05c5c815cfe9e054039e2899",
-        "fingerprint": "bee22a9060b9c83d6e33054125f8cd55",
-        "original_path": "src/jarabe/desktop/networkviews.py",
+        "name": "testrunner.py",
+        "size": 1607,
+        "sha1": "d51cc4701b3b3c94720264a0a8063e5bccd98b5b",
+        "fingerprint": "ba70dda0e69bc50a2aa661a164a2d4a5",
+        "original_path": "src/jarabe/testrunner.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/controlpanel/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 677,
+        "sha1": "88162a20ff790a3197b028a0b4944e2132af17a0",
+        "fingerprint": "d8e4ebaad68be74e6a2661b164a2a6a7",
+        "original_path": "src/jarabe/controlpanel/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/controlpanel/cmd.py",
+        "type": "file",
+        "name": "cmd.py",
+        "size": 6014,
+        "sha1": "7e819114b8b6489557fd381031480da62f9e88bb",
+        "fingerprint": "f86407aa628ba74af83728f1268a8664",
+        "original_path": "src/jarabe/controlpanel/cmd.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/controlpanel/gui.py",
+        "type": "file",
+        "name": "gui.py",
+        "size": 21442,
+        "sha1": "2ea8bdac215993ff0c146aa4f3640e0dfeefc1f6",
+        "fingerprint": "81206db29edf01b08abeea606d8fb6c2",
+        "original_path": "src/jarabe/controlpanel/gui.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/controlpanel/inlinealert.py",
+        "type": "file",
+        "name": "inlinealert.py",
+        "size": 2747,
+        "sha1": "9f257dd39c9d07dfb6ed33f785e9a30183da54c0",
+        "fingerprint": "58fceeaa56cee7de0aa4e1206d8a07a5",
+        "original_path": "src/jarabe/controlpanel/inlinealert.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/controlpanel/Makefile.am",
+        "type": "file",
+        "name": "Makefile.am",
+        "size": 162,
+        "sha1": "3204e0c969f3329bd331b3a05082e3823d54878b",
+        "fingerprint": "470d1dae26d3d2a377570f06ce37eccf",
+        "original_path": "src/jarabe/controlpanel/Makefile.am",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/controlpanel/sectionview.py",
+        "type": "file",
+        "name": "sectionview.py",
+        "size": 2734,
+        "sha1": "523a5a296e34d173069fa9f16ae5695bc0050c54",
+        "fingerprint": "acacedf21798c74e676603b464aa6985",
+        "original_path": "src/jarabe/controlpanel/sectionview.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/controlpanel/toolbar.py",
+        "type": "file",
+        "name": "toolbar.py",
+        "size": 5055,
+        "sha1": "c9ce20b9b87560f847add97a3450eb7389449dfe",
+        "fingerprint": "ce756fe8ac9dc47b32a4a3e166b302b1",
+        "original_path": "src/jarabe/controlpanel/toolbar.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/desktop/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 677,
+        "sha1": "88162a20ff790a3197b028a0b4944e2132af17a0",
+        "fingerprint": "d8e4ebaad68be74e6a2661b164a2a6a7",
+        "original_path": "src/jarabe/desktop/__init__.py",
         "licenses": [],
         "copyrights": []
       },
@@ -2261,13 +289,608 @@
       "factors": [],
       "score": 100,
       "new": {
-        "path": "src/jarabe/intro/colorpicker.py",
+        "path": "src/jarabe/desktop/activitychooser.py",
         "type": "file",
-        "name": "colorpicker.py",
-        "size": 1572,
-        "sha1": "d8de5269c37d563beed5be95360cf1b19e82037a",
-        "fingerprint": "f8f5f3bae69bcd462aa6a57165a28eac",
-        "original_path": "src/jarabe/intro/colorpicker.py",
+        "name": "activitychooser.py",
+        "size": 11858,
+        "sha1": "86bb0568a05c34643023dea6a69cb25074d58a8d",
+        "fingerprint": "42f06af2c2d4ca1ab49620c2275ade8c",
+        "original_path": "src/jarabe/desktop/activitychooser.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/desktop/favoriteslayout.py",
+        "type": "file",
+        "name": "favoriteslayout.py",
+        "size": 24400,
+        "sha1": "2d778d406c92fe26808240435d10d19dd9d07cc3",
+        "fingerprint": "53300d9ce0d3c414ca06a9b9f6a5ed21",
+        "original_path": "src/jarabe/desktop/favoriteslayout.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/desktop/favoritesview.py",
+        "type": "file",
+        "name": "favoritesview.py",
+        "size": 27752,
+        "sha1": "9b50630db1f7b831a6fe77a17c767a70683e487e",
+        "fingerprint": "dbb562ba89d6f6f69ae3a3a455ef8470",
+        "original_path": "src/jarabe/desktop/favoritesview.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/desktop/friendview.py",
+        "type": "file",
+        "name": "friendview.py",
+        "size": 3275,
+        "sha1": "a878a31b24930bdc72240325648b137e4ceec822",
+        "fingerprint": "bcf8d1a6de89d6c34226e8b074e0b726",
+        "original_path": "src/jarabe/desktop/friendview.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/desktop/grid.py",
+        "type": "file",
+        "name": "grid.py",
+        "size": 7590,
+        "sha1": "8e7b06ca5d80a10ac1e7804dc2634756ce5002a6",
+        "fingerprint": "32e47634ea9ecf3ea966a42576ae33a2",
+        "original_path": "src/jarabe/desktop/grid.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/desktop/groupbox.py",
+        "type": "file",
+        "name": "groupbox.py",
+        "size": 2812,
+        "sha1": "d90d36b79e75bd89bdcca9a2719ffbecbc79c4b3",
+        "fingerprint": "baf4ffb8668be7462a76a00266e2c6ac",
+        "original_path": "src/jarabe/desktop/groupbox.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/desktop/homebackgroundbox.py",
+        "type": "file",
+        "name": "homebackgroundbox.py",
+        "size": 3394,
+        "sha1": "b512e1f003c88cc242324253cd17f48333a73684",
+        "fingerprint": "fa39d9aad6bcc76e27a721c036b2a589",
+        "original_path": "src/jarabe/desktop/homebackgroundbox.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/desktop/homebox.py",
+        "type": "file",
+        "name": "homebox.py",
+        "size": 7912,
+        "sha1": "8dfcf52ac281cabd6c12e81b373ade4e6e5cfde9",
+        "fingerprint": "1860dfb806ce8729a80766e2678ec33f",
+        "original_path": "src/jarabe/desktop/homebox.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/desktop/homewindow.py",
+        "type": "file",
+        "name": "homewindow.py",
+        "size": 11105,
+        "sha1": "4b14c3cb7ebf2d6e464462eadc9759eca13dee33",
+        "fingerprint": "74596fae4418ceac8a922aa17d3a92a4",
+        "original_path": "src/jarabe/desktop/homewindow.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/desktop/keydialog.py",
+        "type": "file",
+        "name": "keydialog.py",
+        "size": 10316,
+        "sha1": "bd48e8beaf21fa239668ef718b38163976d05624",
+        "fingerprint": "b8d69bfee48b588743064db6e5909f46",
+        "original_path": "src/jarabe/desktop/keydialog.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/desktop/Makefile.am",
+        "type": "file",
+        "name": "Makefile.am",
+        "size": 437,
+        "sha1": "e632e2807fc7c4251a93b57d0024c5bff4b07a86",
+        "fingerprint": "f8efb1cbf61fd9e9665bbbe83e8f99c6",
+        "original_path": "src/jarabe/desktop/Makefile.am",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/desktop/meshbox.py",
+        "type": "file",
+        "name": "meshbox.py",
+        "size": 23764,
+        "sha1": "d158fc1b4e164dc23154b332dd1c709b73f89419",
+        "fingerprint": "9ae87faa5efdde322790ab107eb0fca0",
+        "original_path": "src/jarabe/desktop/meshbox.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/desktop/networkviews.py",
+        "type": "file",
+        "name": "networkviews.py",
+        "size": 30613,
+        "sha1": "f292cdfb976fa12d05c5c815cfe9e054039e2899",
+        "fingerprint": "bee22a9060b9c83d6e33054125f8cd55",
+        "original_path": "src/jarabe/desktop/networkviews.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/desktop/schoolserver.py",
+        "type": "file",
+        "name": "schoolserver.py",
+        "size": 5472,
+        "sha1": "744dbe2ebd7def253cb6d0b0fe707b7485005687",
+        "fingerprint": "32b09ba8c68fc7c6ca0267d3259083f0",
+        "original_path": "src/jarabe/desktop/schoolserver.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/desktop/snowflakelayout.py",
+        "type": "file",
+        "name": "snowflakelayout.py",
+        "size": 4462,
+        "sha1": "1dfebdc586bea6d8abb2d8d2c287453242deb241",
+        "fingerprint": "18e1e3cac0a9aeef3006f9b3650a15b9",
+        "original_path": "src/jarabe/desktop/snowflakelayout.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/desktop/transitionbox.py",
+        "type": "file",
+        "name": "transitionbox.py",
+        "size": 2383,
+        "sha1": "8a54936c44ca93176305a2af2e15e0241e63c750",
+        "fingerprint": "dabcffb82e9be7466aa4223367a29626",
+        "original_path": "src/jarabe/desktop/transitionbox.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/desktop/viewcontainer.py",
+        "type": "file",
+        "name": "viewcontainer.py",
+        "size": 2821,
+        "sha1": "6e1ac1cf4f2bf578aa692873e5388ecfe3fa21f8",
+        "fingerprint": "b869c922c28b678e0aa4612365e2b683",
+        "original_path": "src/jarabe/desktop/viewcontainer.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/desktop/viewtoolbar.py",
+        "type": "file",
+        "name": "viewtoolbar.py",
+        "size": 9491,
+        "sha1": "75dab51b0dd3e14ccf9f61081a8b0ee11ef8464b",
+        "fingerprint": "925ce6facbafa54f60a421b30632938e",
+        "original_path": "src/jarabe/desktop/viewtoolbar.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/frame/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 824,
+        "sha1": "6d7fc42ca9b90ecb1c1f5d573a3c297bccfcd9e6",
+        "fingerprint": "d8e4feead68be7466aa460b264a2a6a7",
+        "original_path": "src/jarabe/frame/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/frame/activitiestray.py",
+        "type": "file",
+        "name": "activitiestray.py",
+        "size": 33360,
+        "sha1": "da32c81d8eec6b9a336a8fbacf336a60b8a952ec",
+        "fingerprint": "9a85cfaac4bbbbdd5f1da0e4ffbf5f24",
+        "original_path": "src/jarabe/frame/activitiestray.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/frame/clipboard.py",
+        "type": "file",
+        "name": "clipboard.py",
+        "size": 6200,
+        "sha1": "96d7a152bf308551465e00648a5b8d3f76cc4c77",
+        "fingerprint": "ede17a7ad25bc7ee21a633d67583b7a5",
+        "original_path": "src/jarabe/frame/clipboard.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/frame/clipboardicon.py",
+        "type": "file",
+        "name": "clipboardicon.py",
+        "size": 8071,
+        "sha1": "15bec0855aedb3f09d6e086257baed0e156c8079",
+        "fingerprint": "fee543aa01bac572ea6681347ebde685",
+        "original_path": "src/jarabe/frame/clipboardicon.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/frame/clipboardmenu.py",
+        "type": "file",
+        "name": "clipboardmenu.py",
+        "size": 8708,
+        "sha1": "5f251a2676833eb3b16bd89ef8bddd98cbbd868e",
+        "fingerprint": "1af27da8c69bc4780ee064a92dba8bb2",
+        "original_path": "src/jarabe/frame/clipboardmenu.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/frame/clipboardobject.py",
+        "type": "file",
+        "name": "clipboardobject.py",
+        "size": 4306,
+        "sha1": "065aa62c7941d394ec738298bb2c97fcc83bc90e",
+        "fingerprint": "1ae463faeedbf5ce0a806f1575e35ea8",
+        "original_path": "src/jarabe/frame/clipboardobject.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/frame/clipboardpanelwindow.py",
+        "type": "file",
+        "name": "clipboardpanelwindow.py",
+        "size": 5155,
+        "sha1": "10e2162f45cc8b98449c3c48d7b9c4afc9f717bf",
+        "fingerprint": "e9b8cbd8c21fe4ea2c86e9f464a7cca9",
+        "original_path": "src/jarabe/frame/clipboardpanelwindow.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/frame/clipboardtray.py",
+        "type": "file",
+        "name": "clipboardtray.py",
+        "size": 7144,
+        "sha1": "dd1df8471c474c66a59c809c1e6b3daa9bf16680",
+        "fingerprint": "0efcc0ad5402ec5e4aac21d565ebdc62",
+        "original_path": "src/jarabe/frame/clipboardtray.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/frame/devicestray.py",
+        "type": "file",
+        "name": "devicestray.py",
+        "size": 1901,
+        "sha1": "dd7f3ed92f4622cbfe39d7b53264c9fe47a41bf7",
+        "fingerprint": "90a553b8669bc7de2e3668c165b2862c",
+        "original_path": "src/jarabe/frame/devicestray.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/frame/eventarea.py",
+        "type": "file",
+        "name": "eventarea.py",
+        "size": 5219,
+        "sha1": "69267915b054c03b80b6abd2dd53233948f91a59",
+        "fingerprint": "5875d786ca98e4ee12e8273076a39783",
+        "original_path": "src/jarabe/frame/eventarea.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/frame/frame.py",
+        "type": "file",
+        "name": "frame.py",
+        "size": 9104,
+        "sha1": "9cc8e66b79bab8c1bf8887aee00cbbeb4e57f1c0",
+        "fingerprint": "dea965fafbdb065a4ec6234524339942",
+        "original_path": "src/jarabe/frame/frame.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/frame/frameinvoker.py",
+        "type": "file",
+        "name": "frameinvoker.py",
+        "size": 1345,
+        "sha1": "e50e54888219a980e6d67b529354f072a3ccfbe0",
+        "fingerprint": "9ae4d9a2c69bc7ce26a6e5f024e28ea4",
+        "original_path": "src/jarabe/frame/frameinvoker.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/frame/framewindow.py",
+        "type": "file",
+        "name": "framewindow.py",
+        "size": 5682,
+        "sha1": "8a2e6df614352baf241093e664ad8c77868a3428",
+        "fingerprint": "51b5eb6395897cb26aacb58024c59ef5",
+        "original_path": "src/jarabe/frame/framewindow.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/frame/friendstray.py",
+        "type": "file",
+        "name": "friendstray.py",
+        "size": 4312,
+        "sha1": "7593e936cb4f2bf700cd1f03af4455a0ac605728",
+        "fingerprint": "3eb0cd6a669fc7526b3ec9a46fdb878c",
+        "original_path": "src/jarabe/frame/friendstray.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/frame/Makefile.am",
+        "type": "file",
+        "name": "Makefile.am",
+        "size": 385,
+        "sha1": "74c53cec5699857241e3f788cfa06480921ffe5e",
+        "fingerprint": "e19d1fee02feaf2842ed128eaf27b46c",
+        "original_path": "src/jarabe/frame/Makefile.am",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/frame/notification.py",
+        "type": "file",
+        "name": "notification.py",
+        "size": 10970,
+        "sha1": "ca9dda15ae0bfeb14e5a9d90512bd03da93d6d61",
+        "fingerprint": "53f46d726e1807ef2ac7a0c06eaa8da4",
+        "original_path": "src/jarabe/frame/notification.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/frame/zoomtoolbar.py",
+        "type": "file",
+        "name": "zoomtoolbar.py",
+        "size": 4196,
+        "sha1": "3dee09e0c6a0d8da0d6496a9590f11c1c2418c54",
+        "fingerprint": "717cfbf01a992bd724b620a464839f6f",
+        "original_path": "src/jarabe/frame/zoomtoolbar.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/intro/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 474,
+        "sha1": "67ba25be5bb63ac8ecb5cfe6792810169a3e350c",
+        "fingerprint": "038129d0f91caf523d4b9262bdd5f1f8",
+        "original_path": "src/jarabe/intro/__init__.py",
         "licenses": [],
         "copyrights": []
       },
@@ -2295,6 +918,1213 @@
       "factors": [],
       "score": 100,
       "new": {
+        "path": "src/jarabe/intro/colorpicker.py",
+        "type": "file",
+        "name": "colorpicker.py",
+        "size": 1572,
+        "sha1": "d8de5269c37d563beed5be95360cf1b19e82037a",
+        "fingerprint": "f8f5f3bae69bcd462aa6a57165a28eac",
+        "original_path": "src/jarabe/intro/colorpicker.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/intro/genderpicker.py",
+        "type": "file",
+        "name": "genderpicker.py",
+        "size": 3248,
+        "sha1": "36f2abb02cfe7c81e38f890a72fa1b0a9769c777",
+        "fingerprint": "12f9ea2a8ecf4d566626a13277cae5a2",
+        "original_path": "src/jarabe/intro/genderpicker.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/intro/Makefile.am",
+        "type": "file",
+        "name": "Makefile.am",
+        "size": 135,
+        "sha1": "b1ac2f68b8959a36fdf1fd7ebdc432bbe4d89238",
+        "fingerprint": "498defa166d35abd41bd01088edcba0e",
+        "original_path": "src/jarabe/intro/Makefile.am",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/intro/window.py",
+        "type": "file",
+        "name": "window.py",
+        "size": 13552,
+        "sha1": "44197f8f07a654dcb4aaa12f9279ce50c99dbc7e",
+        "fingerprint": "5bf5cea88cabf3f26e4ec1e8e4d3ae24",
+        "original_path": "src/jarabe/intro/window.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/journal/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 679,
+        "sha1": "50ce8a11c2554f374c990b85a58df27570ae33d2",
+        "fingerprint": "b8a4ebaac69bc74e2aa661a164a28ea6",
+        "original_path": "src/jarabe/journal/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/journal/bundlelauncher.py",
+        "type": "file",
+        "name": "bundlelauncher.py",
+        "size": 2640,
+        "sha1": "cc87b31149094cefb0e6728233068938605fa9d8",
+        "fingerprint": "38ede9a2ae1b67560fa2e0a07ccb8e26",
+        "original_path": "src/jarabe/journal/bundlelauncher.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/journal/detailview.py",
+        "type": "file",
+        "name": "detailview.py",
+        "size": 3968,
+        "sha1": "643e92e4f62b520668ee3e511d8ce9e8bd5ca422",
+        "fingerprint": "faf169b2ee89e4ed463665f564e6e6a4",
+        "original_path": "src/jarabe/journal/detailview.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/journal/expandedentry.py",
+        "type": "file",
+        "name": "expandedentry.py",
+        "size": 20484,
+        "sha1": "78114bd9e62b5bc8e6be54d5d5bb8c6c48f8ea4a",
+        "fingerprint": "a804b7feddef6d24dec762d7fcaa9eaf",
+        "original_path": "src/jarabe/journal/expandedentry.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/journal/iconmodel.py",
+        "type": "file",
+        "name": "iconmodel.py",
+        "size": 4390,
+        "sha1": "bad5e8adb2e987dc63e1e8240ab43d037d16e1fd",
+        "fingerprint": "b9e17d60c29bcd5e1eb443b56de68ea6",
+        "original_path": "src/jarabe/journal/iconmodel.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/journal/iconview.py",
+        "type": "file",
+        "name": "iconview.py",
+        "size": 12200,
+        "sha1": "ebb020d948913f74ef89c9870e4d0770d192bd22",
+        "fingerprint": "f27087ffc70be4c251f7f5f4f6a29f84",
+        "original_path": "src/jarabe/journal/iconview.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/journal/journalactivity.py",
+        "type": "file",
+        "name": "journalactivity.py",
+        "size": 23977,
+        "sha1": "2284fd2226629da274c505cc20273d35ecc30e4c",
+        "fingerprint": "cc69fa14a733fe8f5677273a27ba9177",
+        "original_path": "src/jarabe/journal/journalactivity.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/journal/journalentrybundle.py",
+        "type": "file",
+        "name": "journalentrybundle.py",
+        "size": 3135,
+        "sha1": "72c4b3ef83ae724b244aaa224f7474feca27f3b9",
+        "fingerprint": "3ef4f1eb868bc5ec6aa669a36cb997a6",
+        "original_path": "src/jarabe/journal/journalentrybundle.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/journal/journaltoolbox.py",
+        "type": "file",
+        "name": "journaltoolbox.py",
+        "size": 41932,
+        "sha1": "6d98aae400376ca1bef29ba81c59a2eec39d1d8d",
+        "fingerprint": "f8144375e499ddbefa18a6537f8e5ca1",
+        "original_path": "src/jarabe/journal/journaltoolbox.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/journal/journalwindow.py",
+        "type": "file",
+        "name": "journalwindow.py",
+        "size": 1233,
+        "sha1": "3dabb719b48b425f37adf4fda0a535e43497e5ff",
+        "fingerprint": "f8e153fa568be7622aae63a367aacea7",
+        "original_path": "src/jarabe/journal/journalwindow.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/journal/keepicon.py",
+        "type": "file",
+        "name": "keepicon.py",
+        "size": 2441,
+        "sha1": "09e75da17325bac9c1572a7c189083c802826301",
+        "fingerprint": "f8edc3e8a68ccf672296253164abcde7",
+        "original_path": "src/jarabe/journal/keepicon.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/journal/listmodel.py",
+        "type": "file",
+        "name": "listmodel.py",
+        "size": 10533,
+        "sha1": "a69cd4db6163fed3c64534772c50bba72ef88718",
+        "fingerprint": "dc85a9b2c65bc12216d4237d45ce2ef1",
+        "original_path": "src/jarabe/journal/listmodel.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/journal/listview.py",
+        "type": "file",
+        "name": "listview.py",
+        "size": 34423,
+        "sha1": "75b45749051d348c33d45fb46874dc707e8389a7",
+        "fingerprint": "dec4d4da9d7aff6004e32ef632efc5b0",
+        "original_path": "src/jarabe/journal/listview.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/journal/Makefile.am",
+        "type": "file",
+        "name": "Makefile.am",
+        "size": 441,
+        "sha1": "a3246b60d3d0e49b37105860e410090213dcc31e",
+        "fingerprint": "09aa919c04b58a9dd720123b769b5cee",
+        "original_path": "src/jarabe/journal/Makefile.am",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/journal/misc.py",
+        "type": "file",
+        "name": "misc.py",
+        "size": 14885,
+        "sha1": "d1620f6615148644793ff1162048363acf069c15",
+        "fingerprint": "8be4c3189894821ea7c7eb1e75da7698",
+        "original_path": "src/jarabe/journal/misc.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/journal/modalalert.py",
+        "type": "file",
+        "name": "modalalert.py",
+        "size": 3640,
+        "sha1": "3bbd3bad617dd3e974b67cf0cba82fa7af53a0db",
+        "fingerprint": "c8e067aa0e9bef8e28dc688165fa47a4",
+        "original_path": "src/jarabe/journal/modalalert.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/journal/model.py",
+        "type": "file",
+        "name": "model.py",
+        "size": 31907,
+        "sha1": "5236442a0c7816000e53c0a9abd6372dee6a7493",
+        "fingerprint": "69e145eaf4ee59977ccfac50cfa6a977",
+        "original_path": "src/jarabe/journal/model.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/journal/objectchooser.py",
+        "type": "file",
+        "name": "objectchooser.py",
+        "size": 8575,
+        "sha1": "667d588181c3ac7bf74f90b66620ac28ddce213f",
+        "fingerprint": "5e20ebbeeecd6fcd664221166404e782",
+        "original_path": "src/jarabe/journal/objectchooser.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/journal/palettes.py",
+        "type": "file",
+        "name": "palettes.py",
+        "size": 25982,
+        "sha1": "aa59464762ed97b59c8eb9c89b4eb5ce801b7f24",
+        "fingerprint": "f87dfff26a1fc49a9617c65f44ab0760",
+        "original_path": "src/jarabe/journal/palettes.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/journal/projectview.py",
+        "type": "file",
+        "name": "projectview.py",
+        "size": 5486,
+        "sha1": "bea7d8d5de546621bf114984ca63211834858c4f",
+        "fingerprint": "dab4f7bcd0aee5fae626474077b686e4",
+        "original_path": "src/jarabe/journal/projectview.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/journal/volumestoolbar.py",
+        "type": "file",
+        "name": "volumestoolbar.py",
+        "size": 13220,
+        "sha1": "1bb400584046ea2a5f1bd725174754c1b494ac4e",
+        "fingerprint": "18c8e22ad09fc09a38bc24302c2e2626",
+        "original_path": "src/jarabe/journal/volumestoolbar.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/model/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 677,
+        "sha1": "88162a20ff790a3197b028a0b4944e2132af17a0",
+        "fingerprint": "d8e4ebaad68be74e6a2661b164a2a6a7",
+        "original_path": "src/jarabe/model/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/model/adhoc.py",
+        "type": "file",
+        "name": "adhoc.py",
+        "size": 11641,
+        "sha1": "430dc30d4a5a3ad7dee541f4e592e13355f680b1",
+        "fingerprint": "ea8247aa065c4cfe0aee07b566c184e9",
+        "original_path": "src/jarabe/model/adhoc.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/model/brightness.py",
+        "type": "file",
+        "name": "brightness.py",
+        "size": 4879,
+        "sha1": "184b2822b3f35a423688307009791037e4865c6d",
+        "fingerprint": "cce4cfe48711e76f2a36228261aa8689",
+        "original_path": "src/jarabe/model/brightness.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/model/buddy.py",
+        "type": "file",
+        "name": "buddy.py",
+        "size": 6429,
+        "sha1": "0c75cf0f14fa2ba57b795068984c031ff722365d",
+        "fingerprint": "b420c7e8f6cf065239e4f281642af5ab",
+        "original_path": "src/jarabe/model/buddy.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/model/bundleregistry.py",
+        "type": "file",
+        "name": "bundleregistry.py",
+        "size": 27763,
+        "sha1": "3eb3a117cc6cad760d1f78a27dfbbfed09af03b6",
+        "fingerprint": "db2867bc927d405211cb023a44822866",
+        "original_path": "src/jarabe/model/bundleregistry.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/model/desktop.py",
+        "type": "file",
+        "name": "desktop.py",
+        "size": 3714,
+        "sha1": "6e5e6de680e23ffc0bb6f4e4f714469cec0d1013",
+        "fingerprint": "d8fc4bb0829be54716a0e1a364aa8cbf",
+        "original_path": "src/jarabe/model/desktop.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/model/filetransfer.py",
+        "type": "file",
+        "name": "filetransfer.py",
+        "size": 13272,
+        "sha1": "6cc15e7c200ad96067fc34496f1edfcfe190a55d",
+        "fingerprint": "980d63a2ec8b55cb3296b0fc70bfde1e",
+        "original_path": "src/jarabe/model/filetransfer.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/model/friends.py",
+        "type": "file",
+        "name": "friends.py",
+        "size": 5278,
+        "sha1": "f9786839cecc0a9e157144c6759b5e72aa5446dd",
+        "fingerprint": "1fa4e37a568b27502626673524f2d2aa",
+        "original_path": "src/jarabe/model/friends.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/model/invites.py",
+        "type": "file",
+        "name": "invites.py",
+        "size": 12064,
+        "sha1": "ce63d660616cfb35a20538428cef8ea2c858e6d8",
+        "fingerprint": "93ec6388de1ffc6a12e4e73a74e39a0d",
+        "original_path": "src/jarabe/model/invites.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/model/keyboard.py",
+        "type": "file",
+        "name": "keyboard.py",
+        "size": 2222,
+        "sha1": "de63e99ccdc829360439d9d6becb897affa63926",
+        "fingerprint": "72f12e68429bc70e0ab263a264e296e5",
+        "original_path": "src/jarabe/model/keyboard.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/model/Makefile.am",
+        "type": "file",
+        "name": "Makefile.am",
+        "size": 473,
+        "sha1": "4a400df1a95aaa822319795b663e460e5efe1e82",
+        "fingerprint": "e09d81380a6b02430a637947fc22f580",
+        "original_path": "src/jarabe/model/Makefile.am",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/model/mimeregistry.py",
+        "type": "file",
+        "name": "mimeregistry.py",
+        "size": 1565,
+        "sha1": "5a28013a857907f3b0411500746823731b6e8745",
+        "fingerprint": "b8f1efa0e69bc54e282661b124aa86a3",
+        "original_path": "src/jarabe/model/mimeregistry.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/model/neighborhood.py",
+        "type": "file",
+        "name": "neighborhood.py",
+        "size": 45220,
+        "sha1": "f9c90d3d014a1cb56604918655da5b094356e3be",
+        "fingerprint": "ba3c419c8f8893d22943f61666bbe70c",
+        "original_path": "src/jarabe/model/neighborhood.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/model/network.py",
+        "type": "file",
+        "name": "network.py",
+        "size": 41904,
+        "sha1": "8ef19f55176aa33f73880394c4009fde5b2d3b57",
+        "fingerprint": "9e5452327e9c8359a2c20b8d47f75cb1",
+        "original_path": "src/jarabe/model/network.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/model/notifications.py",
+        "type": "file",
+        "name": "notifications.py",
+        "size": 4491,
+        "sha1": "8ec982bd679849d365d9332578771d68fd73ece2",
+        "fingerprint": "b974e028e689846232a621e36caaa6af",
+        "original_path": "src/jarabe/model/notifications.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/model/olpcmesh.py",
+        "type": "file",
+        "name": "olpcmesh.py",
+        "size": 9357,
+        "sha1": "74ca9a108ec1e8a26e4151eb9035e73159becb13",
+        "fingerprint": "acb078ecd799d5603eb225e726fba4a2",
+        "original_path": "src/jarabe/model/olpcmesh.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/model/screen.py",
+        "type": "file",
+        "name": "screen.py",
+        "size": 1428,
+        "sha1": "eec7eca4b12a59b85794cf1c6886e0470d23aa9d",
+        "fingerprint": "3ae5e3aa969bc7426a2461a165a2d7a7",
+        "original_path": "src/jarabe/model/screen.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/model/screenshot.py",
+        "type": "file",
+        "name": "screenshot.py",
+        "size": 3989,
+        "sha1": "fa06fba647be031477b743088dbfb0be9abe669f",
+        "fingerprint": "d82167a274fb85cda2ae899076e2a4ec",
+        "original_path": "src/jarabe/model/screenshot.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/model/session.py",
+        "type": "file",
+        "name": "session.py",
+        "size": 4553,
+        "sha1": "37be5fc32cb5a41cb0a487b6838031cc71cdbb22",
+        "fingerprint": "fea17fb0d29de5562286a15064b214e5",
+        "original_path": "src/jarabe/model/session.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/model/shell.py",
+        "type": "file",
+        "name": "shell.py",
+        "size": 28024,
+        "sha1": "abee773ffbe9f67244e387abf2fe89c932b25710",
+        "fingerprint": "17adf56bb57e6ec6604a696cd4f790be",
+        "original_path": "src/jarabe/model/shell.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/model/sound.py",
+        "type": "file",
+        "name": "sound.py",
+        "size": 2736,
+        "sha1": "a5f1580f934949f7fe8911d2c72bf4dd41d189d6",
+        "fingerprint": "aa7cebecee8a45cf49a609d465a29eb1",
+        "original_path": "src/jarabe/model/sound.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/model/speech.py",
+        "type": "file",
+        "name": "speech.py",
+        "size": 978,
+        "sha1": "bdf05ff03a07aca5d0de3ee05eedd51f0f6af240",
+        "fingerprint": "b8e5efaac69ac74e6a2660a364aa8ea4",
+        "original_path": "src/jarabe/model/speech.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/model/telepathyclient.py",
+        "type": "file",
+        "name": "telepathyclient.py",
+        "size": 5202,
+        "sha1": "0b0d1500ca8a16f4a2d5edb9794568c9fd1b9953",
+        "fingerprint": "7e24fbac6289e746202ee72c6482f3c4",
+        "original_path": "src/jarabe/model/telepathyclient.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/model/update/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 1074,
+        "sha1": "c50ba895727228ef71828191606b24d8ec906646",
+        "fingerprint": "d864e2ae469bc7ca2a2663b164aba7a4",
+        "original_path": "src/jarabe/model/update/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/model/update/aslo.py",
+        "type": "file",
+        "name": "aslo.py",
+        "size": 6700,
+        "sha1": "65a1f059015d567a7be1597ce2eb388cfd4687ff",
+        "fingerprint": "10b1fea46393c18a2cace0b2c6aa24e1",
+        "original_path": "src/jarabe/model/update/aslo.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/model/update/Makefile.am",
+        "type": "file",
+        "name": "Makefile.am",
+        "size": 119,
+        "sha1": "93c092ca71a9f768ef2eaa4d8815360224f5a353",
+        "fingerprint": "4248972bae13126039d63242aafc4aac",
+        "original_path": "src/jarabe/model/update/Makefile.am",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/model/update/microformat.py",
+        "type": "file",
+        "name": "microformat.py",
+        "size": 16823,
+        "sha1": "81cc0a1de95ac4c9b204d4f7e19474a46ff8c793",
+        "fingerprint": "d34578f85c07e55f2e3478aa2cc23d02",
+        "original_path": "src/jarabe/model/update/microformat.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/model/update/updater.py",
+        "type": "file",
+        "name": "updater.py",
+        "size": 10563,
+        "sha1": "88f7186ef2cedb170f3522ffc3a80df673dd2c1e",
+        "fingerprint": "b869e7e9c588ca5a6094c8f32d83def1",
+        "original_path": "src/jarabe/model/update/updater.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/util/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 721,
+        "sha1": "07d09709f3b7e592087c1e75996f1c6eb2bb33b9",
+        "fingerprint": "b8e4ebaaf68bc74e2aa660a164aa86a4",
+        "original_path": "src/jarabe/util/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/util/downloader.py",
+        "type": "file",
+        "name": "downloader.py",
+        "size": 8616,
+        "sha1": "471dfa347b25cb2b5e62b117db22c9fa9227ae93",
+        "fingerprint": "d99c45a45e8b67472707a1bd76a65d53",
+        "original_path": "src/jarabe/util/downloader.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/util/httprange.py",
+        "type": "file",
+        "name": "httprange.py",
+        "size": 2746,
+        "sha1": "ab9c70e9dd660062a8e4463c79edd097e072e9fe",
+        "fingerprint": "9ce03ff2f21bf7624ab461b1648686b2",
+        "original_path": "src/jarabe/util/httprange.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/util/Makefile.am",
+        "type": "file",
+        "name": "Makefile.am",
+        "size": 171,
+        "sha1": "a36379897330ced7a918be9f4d1fe5bb0918725a",
+        "fingerprint": "6dcf43a2c3955a09e9df292bdb88bbec",
+        "original_path": "src/jarabe/util/Makefile.am",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/util/telepathy/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 731,
+        "sha1": "697c8fe6a59f7c7fe8026bba569135ebe6a1755b",
+        "fingerprint": "b8a46baaf69bc74e2aa661a064aa86a7",
+        "original_path": "src/jarabe/util/telepathy/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/util/telepathy/connection_watcher.py",
+        "type": "file",
+        "name": "connection_watcher.py",
+        "size": 4033,
+        "sha1": "1e8b9a73e21ea2daddcbe9dc125693cba96111b6",
+        "fingerprint": "5eedebfa5e594f4e02a6031126c8e6bd",
+        "original_path": "src/jarabe/util/telepathy/connection_watcher.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/util/telepathy/Makefile.am",
+        "type": "file",
+        "name": "Makefile.am",
+        "size": 111,
+        "sha1": "162644a57f08fea633dec414d02981394143cfc0",
+        "fingerprint": "e15d522ebcd3f8b1cc6e43ca1a97fe5e",
+        "original_path": "src/jarabe/util/telepathy/Makefile.am",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/view/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 677,
+        "sha1": "88162a20ff790a3197b028a0b4944e2132af17a0",
+        "fingerprint": "d8e4ebaad68be74e6a2661b164a2a6a7",
+        "original_path": "src/jarabe/view/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/view/alerts.py",
+        "type": "file",
+        "name": "alerts.py",
+        "size": 2055,
+        "sha1": "0b2eaa6e3c6646cf685089827f2857fe55c6710e",
+        "fingerprint": "fa6cecf2c69fc442223423846da2c6a4",
+        "original_path": "src/jarabe/view/alerts.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/view/buddyicon.py",
+        "type": "file",
+        "name": "buddyicon.py",
+        "size": 2754,
+        "sha1": "1b2f5913b20b3969285e0541f65e276e5d262db5",
+        "fingerprint": "baf4f3a2168be5c62a3760f166a2c6a8",
+        "original_path": "src/jarabe/view/buddyicon.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/view/buddymenu.py",
+        "type": "file",
+        "name": "buddymenu.py",
+        "size": 8681,
+        "sha1": "0c3d6b444da40574cd7f225f491221efaaaf1bbd",
+        "fingerprint": "8bed778ac79905421bb4e19464a7af2e",
+        "original_path": "src/jarabe/view/buddymenu.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/view/cursortracker.py",
+        "type": "file",
+        "name": "cursortracker.py",
+        "size": 1728,
+        "sha1": "c7d296d7ea47181cb8d1a86ba6aa45e435d24e31",
+        "fingerprint": "5aaceeeac68b8d4a2a1461e266b38b60",
+        "original_path": "src/jarabe/view/cursortracker.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/view/customizebundle.py",
+        "type": "file",
+        "name": "customizebundle.py",
+        "size": 7423,
+        "sha1": "18b063de275c737138412143a655a67f6b4bb4f2",
+        "fingerprint": "97f0c7a316536fdc6a0c60321cc585a0",
+        "original_path": "src/jarabe/view/customizebundle.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/view/gesturehandler.py",
+        "type": "file",
+        "name": "gesturehandler.py",
+        "size": 2473,
+        "sha1": "13ec850db86f39ff6b75a83e474b58a96ecac838",
+        "fingerprint": "daf9e8e24e9bef6e2aa661f265bf9684",
+        "original_path": "src/jarabe/view/gesturehandler.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/view/keyhandler.py",
+        "type": "file",
+        "name": "keyhandler.py",
+        "size": 8759,
+        "sha1": "2a53e8f18abc8c2162e14c7476d20b415005e3f6",
+        "fingerprint": "c8f964e48fbaef420117a1a82ef2df28",
+        "original_path": "src/jarabe/view/keyhandler.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/view/launcher.py",
+        "type": "file",
+        "name": "launcher.py",
+        "size": 6044,
+        "sha1": "9b7f24c52515bd673bc2fe86be47460107e26c9f",
+        "fingerprint": "baf5d3ea1a8a7e9e23a5e3a067b2aa18",
+        "original_path": "src/jarabe/view/launcher.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/view/Makefile.am",
+        "type": "file",
+        "name": "Makefile.am",
+        "size": 382,
+        "sha1": "1f7576f59fb572e878262fe71a7859f50020fc3f",
+        "fingerprint": "c53a72962eb0f3a1ac0fb2f40bbdc9ae",
+        "original_path": "src/jarabe/view/Makefile.am",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/view/palettes.py",
+        "type": "file",
+        "name": "palettes.py",
+        "size": 11628,
+        "sha1": "e2a5f5655204ecb2f698f0b56b6e081b1bf37e64",
+        "fingerprint": "f33dd923ffeec4ee38b4264f3fc709a1",
+        "original_path": "src/jarabe/view/palettes.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
         "path": "src/jarabe/view/pulsingicon.py",
         "type": "file",
         "name": "pulsingicon.py",
@@ -2308,18 +2138,222 @@
       "old": null
     },
     {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/view/service.py",
+        "type": "file",
+        "name": "service.py",
+        "size": 3237,
+        "sha1": "b6ec741d8b3a269dd9db610635fdc75d3a988bc4",
+        "fingerprint": "f2eccbd4eebbcf41222661d064ea9eb6",
+        "original_path": "src/jarabe/view/service.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/view/tabbinghandler.py",
+        "type": "file",
+        "name": "tabbinghandler.py",
+        "size": 6108,
+        "sha1": "00a4e0149fa078d24965bce5b0811c64b9331655",
+        "fingerprint": "522345b05ab98d1622caa5936cbac5e4",
+        "original_path": "src/jarabe/view/tabbinghandler.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/view/viewhelp.py",
+        "type": "file",
+        "name": "viewhelp.py",
+        "size": 12241,
+        "sha1": "512092ef1ea663f87b58ce7391fba1a8520602fc",
+        "fingerprint": "8ef1cebaa4974c78473c03f007869aa0",
+        "original_path": "src/jarabe/view/viewhelp.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/view/viewhelp_webkit1.py",
+        "type": "file",
+        "name": "viewhelp_webkit1.py",
+        "size": 4473,
+        "sha1": "9bddebeae693d2bac8ea53c3cc038d99576cd3b7",
+        "fingerprint": "38e4cfea8290657e62a6213167a78525",
+        "original_path": "src/jarabe/view/viewhelp_webkit1.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/view/viewhelp_webkit2.py",
+        "type": "file",
+        "name": "viewhelp_webkit2.py",
+        "size": 3617,
+        "sha1": "365a64c1e255e85a74e8fed2d7303fed7c2ea81e",
+        "fingerprint": "7c60cfe2de9bc5ceea2621716fa4a786",
+        "original_path": "src/jarabe/view/viewhelp_webkit2.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/view/viewsource.py",
+        "type": "file",
+        "name": "viewsource.py",
+        "size": 30015,
+        "sha1": "9a740f4382b41b44b2f48dd7270852edce564cfb",
+        "fingerprint": "d4c74bfc9ab8cddff27f6ae352f2168e",
+        "original_path": "src/jarabe/view/viewsource.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/webservice/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 0,
+        "sha1": null,
+        "fingerprint": null,
+        "original_path": "src/jarabe/webservice/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/webservice/account.py",
+        "type": "file",
+        "name": "account.py",
+        "size": 3590,
+        "sha1": "b575677957524c07b40d7e0199ce2b96e91dee20",
+        "fingerprint": "a0f558b0561fdf0f796441f320bb9ac5",
+        "original_path": "src/jarabe/webservice/account.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/webservice/accountsmanager.py",
+        "type": "file",
+        "name": "accountsmanager.py",
+        "size": 7106,
+        "sha1": "c2ec06ae0baf6a4bddec6c72fc7838ef64753c4e",
+        "fingerprint": "b4e577ea824bf3c662640de12d1ff585",
+        "original_path": "src/jarabe/webservice/accountsmanager.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
+      "status": "added",
+      "factors": [],
+      "score": 100,
+      "new": {
+        "path": "src/jarabe/webservice/Makefile.am",
+        "type": "file",
+        "name": "Makefile.am",
+        "size": 112,
+        "sha1": "218824a95b6065b00ce5f275f37696d5c03e61c4",
+        "fingerprint": "2385043ee21bd23d592558160cd5b38a",
+        "original_path": "src/jarabe/webservice/Makefile.am",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": null
+    },
+    {
       "status": "removed",
       "factors": [],
       "score": 0,
       "new": null,
       "old": {
-        "path": "coalib/bears/requirements/PipRequirement.py",
+        "path": "coalib/__init__.py",
         "type": "file",
-        "name": "PipRequirement.py",
-        "size": 847,
-        "sha1": "2de354930248f786449c8a1993af9f3564c6afd3",
-        "fingerprint": "1130f2506e1a4420c209dbc61a285300",
-        "original_path": "coalib/bears/requirements/PipRequirement.py",
+        "name": "__init__.py",
+        "size": 592,
+        "sha1": "8adecf7174a46ffac9c3d66a3bcb73b36445adb8",
+        "fingerprint": "5aea4a72133d2436c53a0ba7d7a61d2c",
+        "original_path": "coalib/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/coala.py",
+        "type": "file",
+        "name": "coala.py",
+        "size": 2836,
+        "sha1": "2225cfa2e760261b02d5eb37a3d318c0b4fb2fb1",
+        "fingerprint": "38a5e5aa22cdc5e33276eda275afaf6d",
+        "original_path": "coalib/coala.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/coala_ci.py",
+        "type": "file",
+        "name": "coala_ci.py",
+        "size": 1268,
+        "sha1": "f2c064700aa6d83522cbe7eeef5f3fd47a0739d4",
+        "fingerprint": "98a9edaa529dc523723eedb665b7efaf",
+        "original_path": "coalib/coala_ci.py",
         "licenses": [],
         "copyrights": []
       }
@@ -2347,6 +2381,23 @@
       "score": 0,
       "new": null,
       "old": {
+        "path": "coalib/coala_delete_orig.py",
+        "type": "file",
+        "name": "coala_delete_orig.py",
+        "size": 1450,
+        "sha1": "ba470220cfe23896e03e01094899e6fe94e37a3a",
+        "fingerprint": "d98322005edec725659f7ca9b42aab2c",
+        "original_path": "coalib/coala_delete_orig.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
         "path": "coalib/coala_format.py",
         "type": "file",
         "name": "coala_format.py",
@@ -2364,13 +2415,13 @@
       "score": 0,
       "new": null,
       "old": {
-        "path": "coalib/results/result_actions/ResultAction.py",
+        "path": "coalib/coala_json.py",
         "type": "file",
-        "name": "ResultAction.py",
-        "size": 3534,
-        "sha1": "6bf770d692b451f5d0ccfc17b9dd24c82ac43745",
-        "fingerprint": "145051da4cea0672c65bdae10b4e0b63",
-        "original_path": "coalib/results/result_actions/ResultAction.py",
+        "name": "coala_json.py",
+        "size": 2137,
+        "sha1": "cd70a96cbed7fa84704a21f777490e5b7edf671e",
+        "fingerprint": "99bfb5ea528ec5b7b220e9a85893cfa7",
+        "original_path": "coalib/coala_json.py",
         "licenses": [],
         "copyrights": []
       }
@@ -2381,13 +2432,13 @@
       "score": 0,
       "new": null,
       "old": {
-        "path": "coalib/settings/DocstringMetadata.py",
+        "path": "coalib/coala_main.py",
         "type": "file",
-        "name": "DocstringMetadata.py",
-        "size": 2495,
-        "sha1": "027f523e4098610452e54bf6c3f96610f0aec7cf",
-        "fingerprint": "48b8eaa17445cb47e1d89a77cddaf97a",
-        "original_path": "coalib/settings/DocstringMetadata.py",
+        "name": "coala_main.py",
+        "size": 5013,
+        "sha1": "1d92b5257fded9b408a579c0fc13d83f0c455c86",
+        "fingerprint": "78f4dc871b1e370185e021193b3734cd",
+        "original_path": "coalib/coala_main.py",
         "licenses": [],
         "copyrights": []
       }
@@ -2398,13 +2449,13 @@
       "score": 0,
       "new": null,
       "old": {
-        "path": "coalib/settings/FunctionMetadata.py",
+        "path": "coalib/default_coafile",
         "type": "file",
-        "name": "FunctionMetadata.py",
-        "size": 10507,
-        "sha1": "f4da0dce54826c68cb3241e27b09d4478abf23d1",
-        "fingerprint": "7060282c309df21dbf024d9387b674af",
-        "original_path": "coalib/settings/FunctionMetadata.py",
+        "name": "default_coafile",
+        "size": 0,
+        "sha1": null,
+        "fingerprint": null,
+        "original_path": "coalib/default_coafile",
         "licenses": [],
         "copyrights": []
       }
@@ -2415,13 +2466,472 @@
       "score": 0,
       "new": null,
       "old": {
-        "path": "coalib/coala_delete_orig.py",
+        "path": "coalib/VERSION",
         "type": "file",
-        "name": "coala_delete_orig.py",
-        "size": 1450,
-        "sha1": "ba470220cfe23896e03e01094899e6fe94e37a3a",
-        "fingerprint": "d98322005edec725659f7ca9b42aab2c",
-        "original_path": "coalib/coala_delete_orig.py",
+        "name": "VERSION",
+        "size": 6,
+        "sha1": "8606c087f8b6f1684acd81984a1b1723c35f95c1",
+        "fingerprint": "1f9fea2088b09fd355ce4bac1ba93ee9",
+        "original_path": "coalib/VERSION",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/bearlib/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 211,
+        "sha1": "4cef36542f76d618ef6d258b2f1adc90e5d545da",
+        "fingerprint": "7688102f13925981f20810ae3e480c5f",
+        "original_path": "coalib/bearlib/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/bearlib/abstractions/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 110,
+        "sha1": "7470ffdc8bb4a378866338e5ab0e14789b8dcb6a",
+        "fingerprint": "155828fa383550138b34f6cef327030c",
+        "original_path": "coalib/bearlib/abstractions/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/bearlib/abstractions/ExternalBearWrap.py",
+        "type": "file",
+        "name": "ExternalBearWrap.py",
+        "size": 7867,
+        "sha1": "161505af88d7b664904da509f91ac9ac2b3cd742",
+        "fingerprint": "b8c47183ea595f200dab02d485b6d16c",
+        "original_path": "coalib/bearlib/abstractions/ExternalBearWrap.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/bearlib/abstractions/Lint.py",
+        "type": "file",
+        "name": "Lint.py",
+        "size": 15710,
+        "sha1": "b430f0c735ca261779204a76e88658c21a6e8210",
+        "fingerprint": "b0e3971ba8512f7e537c6ccf699b5ab2",
+        "original_path": "coalib/bearlib/abstractions/Lint.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/bearlib/abstractions/Linter.py",
+        "type": "file",
+        "name": "Linter.py",
+        "size": 31946,
+        "sha1": "6ca88650c2d066a005333598736ab715b315be59",
+        "fingerprint": "2ae7c5cb283137770c7448ed2f8a797f",
+        "original_path": "coalib/bearlib/abstractions/Linter.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/bearlib/abstractions/SectionCreatable.py",
+        "type": "file",
+        "name": "SectionCreatable.py",
+        "size": 2611,
+        "sha1": "c2a937979d1fa6f15d1f3a5d081fc655e6aa8b8c",
+        "fingerprint": "55a1bd1f39edec7f3923c2f47c7a3a0f",
+        "original_path": "coalib/bearlib/abstractions/SectionCreatable.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/bearlib/languages/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 86,
+        "sha1": "b5fd238b55022311cd4fcaa2635bf058a7a78660",
+        "fingerprint": "6895b8636b8cc861c715c67c7af609bb",
+        "original_path": "coalib/bearlib/languages/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/bearlib/languages/LanguageDefinition.py",
+        "type": "file",
+        "name": "LanguageDefinition.py",
+        "size": 1438,
+        "sha1": "2536c0a6d2093e584da16f29873661c44f5e118e",
+        "fingerprint": "b786be2e33146975211d2015109cffc0",
+        "original_path": "coalib/bearlib/languages/LanguageDefinition.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/bearlib/languages/definitions/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 341,
+        "sha1": "87d64b589629f8347219295d2ef4225a5c8328c9",
+        "fingerprint": "be9d7000b7bbecae1169b75939c8e4a9",
+        "original_path": "coalib/bearlib/languages/definitions/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/bearlib/languages/definitions/c.coalang",
+        "type": "file",
+        "name": "c.coalang",
+        "size": 568,
+        "sha1": "a6f2eeb3d4a7a983bdec457cf438bebc5e96d429",
+        "fingerprint": "8d91eb5c609d76bddaf1c2443983596c",
+        "original_path": "coalib/bearlib/languages/definitions/c.coalang",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/bearlib/languages/definitions/cpp.coalang",
+        "type": "file",
+        "name": "cpp.coalang",
+        "size": 1057,
+        "sha1": "eeae9b0805d0a73ec9776ca22b167b4c35fbd9d4",
+        "fingerprint": "4c81f332400813355093b2419a3219a5",
+        "original_path": "coalib/bearlib/languages/definitions/cpp.coalang",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/bearlib/languages/definitions/python3.coalang",
+        "type": "file",
+        "name": "python3.coalang",
+        "size": 197,
+        "sha1": "9d2b3693ee8ce866ce05f33132f9139d8effe113",
+        "fingerprint": "4e13ff2ee8b1291acebd8a25322f308a",
+        "original_path": "coalib/bearlib/languages/definitions/python3.coalang",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/bearlib/languages/documentation/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 131,
+        "sha1": "eb5fe0a696ffb1729c1d59ca79c7c8c41294b6a5",
+        "fingerprint": "4efe1f6ffd1ceb9b41961ab0345dd9f8",
+        "original_path": "coalib/bearlib/languages/documentation/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/bearlib/languages/documentation/default.coalang",
+        "type": "file",
+        "name": "default.coalang",
+        "size": 68,
+        "sha1": "7f0974af6b1eaae9bae4c6da6cff997d8e30391b",
+        "fingerprint": "29648818f15009000691631ec22a1e20",
+        "original_path": "coalib/bearlib/languages/documentation/default.coalang",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/bearlib/languages/documentation/DocstyleDefinition.py",
+        "type": "file",
+        "name": "DocstyleDefinition.py",
+        "size": 5815,
+        "sha1": "2f7a7bf51563d4db2ca4e26a5564fc70a22af029",
+        "fingerprint": "3afc41add5d7163401300fa7a0dc5544",
+        "original_path": "coalib/bearlib/languages/documentation/DocstyleDefinition.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/bearlib/languages/documentation/DocumentationComment.py",
+        "type": "file",
+        "name": "DocumentationComment.py",
+        "size": 5150,
+        "sha1": "505a3cf1cff6b8550cc45f3bf8989c27c81e4415",
+        "fingerprint": "0a24c66a1c169d373491cfa93cd2ae10",
+        "original_path": "coalib/bearlib/languages/documentation/DocumentationComment.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/bearlib/languages/documentation/DocumentationExtraction.py",
+        "type": "file",
+        "name": "DocumentationExtraction.py",
+        "size": 11244,
+        "sha1": "7795573d96ef91b34a4cbed6fb9ed2b2a6c48834",
+        "fingerprint": "90a8d09d58849706b215f5e6f051f985",
+        "original_path": "coalib/bearlib/languages/documentation/DocumentationExtraction.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/bearlib/languages/documentation/doxygen.coalang",
+        "type": "file",
+        "name": "doxygen.coalang",
+        "size": 1215,
+        "sha1": "df1da2a93331aa0672bc7810b88aaedd83d6b3f4",
+        "fingerprint": "f047b03a7bb083b348ba4b9ab6bc2a38",
+        "original_path": "coalib/bearlib/languages/documentation/doxygen.coalang",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/bearlib/naming_conventions/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 3507,
+        "sha1": "04c549b54d2b6eee40ac41e8e05d2cf48d7fd632",
+        "fingerprint": "7b59879d408150c78e4c5f5a2b057003",
+        "original_path": "coalib/bearlib/naming_conventions/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/bearlib/spacing/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 0,
+        "sha1": null,
+        "fingerprint": null,
+        "original_path": "coalib/bearlib/spacing/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/bearlib/spacing/SpacingHelper.py",
+        "type": "file",
+        "name": "SpacingHelper.py",
+        "size": 3809,
+        "sha1": "33ccbfc6383e8559bec62c7f43a39e2022c427a2",
+        "fingerprint": "159b24c21e6bda7e3d8c079f52b8be0c",
+        "original_path": "coalib/bearlib/spacing/SpacingHelper.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/bears/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 0,
+        "sha1": null,
+        "fingerprint": null,
+        "original_path": "coalib/bears/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/bears/Bear.py",
+        "type": "file",
+        "name": "Bear.py",
+        "size": 13931,
+        "sha1": "2a8383187dd5217c18741bbb979d9d513abc4f9f",
+        "fingerprint": "a658793a6fed424181d6043a3ad23a2f",
+        "original_path": "coalib/bears/Bear.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/bears/BEAR_KIND.py",
+        "type": "file",
+        "name": "BEAR_KIND.py",
+        "size": 71,
+        "sha1": "1dedd6553debf266c2640412be83ce83f790ee5a",
+        "fingerprint": "04e4c4c01c84756e028240c8400c419e",
+        "original_path": "coalib/bears/BEAR_KIND.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/bears/GlobalBear.py",
+        "type": "file",
+        "name": "GlobalBear.py",
+        "size": 1175,
+        "sha1": "5bcacff0da623782a10a06c372068f8c75a0f1c8",
+        "fingerprint": "5d34b77657e13d2ce4c1004619cd5c53",
+        "original_path": "coalib/bears/GlobalBear.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/bears/LocalBear.py",
+        "type": "file",
+        "name": "LocalBear.py",
+        "size": 1523,
+        "sha1": "171aab7341ee0465c3353f651108e1ab8816778e",
+        "fingerprint": "566ef2ad89495fb6338f0bb5022d9f75",
+        "original_path": "coalib/bears/LocalBear.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/bears/requirements/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 0,
+        "sha1": null,
+        "fingerprint": null,
+        "original_path": "coalib/bears/requirements/__init__.py",
         "licenses": [],
         "copyrights": []
       }
@@ -2466,13 +2976,13 @@
       "score": 0,
       "new": null,
       "old": {
-        "path": "coalib/processes/CONTROL_ELEMENT.py",
+        "path": "coalib/bears/requirements/PackageRequirement.py",
         "type": "file",
-        "name": "CONTROL_ELEMENT.py",
-        "size": 114,
-        "sha1": "8830c48ff828d0d93a1e37b83f411fa3b8eb238a",
-        "fingerprint": "84424c804091b01202101c0a229c93de",
-        "original_path": "coalib/processes/CONTROL_ELEMENT.py",
+        "name": "PackageRequirement.py",
+        "size": 4261,
+        "sha1": "52be29490537645a298a16020c53c7fa8607b0e8",
+        "fingerprint": "8726332c80c5512cb636c877ebb9d1b1",
+        "original_path": "coalib/bears/requirements/PackageRequirement.py",
         "licenses": [],
         "copyrights": []
       }
@@ -2483,1033 +2993,13 @@
       "score": 0,
       "new": null,
       "old": {
-        "path": "coalib/__init__.py",
+        "path": "coalib/bears/requirements/PipRequirement.py",
         "type": "file",
-        "name": "__init__.py",
-        "size": 592,
-        "sha1": "8adecf7174a46ffac9c3d66a3bcb73b36445adb8",
-        "fingerprint": "5aea4a72133d2436c53a0ba7d7a61d2c",
-        "original_path": "coalib/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/bearlib/abstractions/SectionCreatable.py",
-        "type": "file",
-        "name": "SectionCreatable.py",
-        "size": 2611,
-        "sha1": "c2a937979d1fa6f15d1f3a5d081fc655e6aa8b8c",
-        "fingerprint": "55a1bd1f39edec7f3923c2f47c7a3a0f",
-        "original_path": "coalib/bearlib/abstractions/SectionCreatable.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/settings/Section.py",
-        "type": "file",
-        "name": "Section.py",
-        "size": 8755,
-        "sha1": "c2dd35d5c718ea706bc6869539f9ae568945e8de",
-        "fingerprint": "4778cc063d1df6faaa57173f6ad98770",
-        "original_path": "coalib/settings/Section.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/output/ConfWriter.py",
-        "type": "file",
-        "name": "ConfWriter.py",
-        "size": 4015,
-        "sha1": "2ae75d42ae63cda2ee490434b995c6a93ad4a8a0",
-        "fingerprint": "febc7e7552bfc1b5fdb8a5bf49cd02a0",
-        "original_path": "coalib/output/ConfWriter.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/bearlib/languages/definitions/python3.coalang",
-        "type": "file",
-        "name": "python3.coalang",
-        "size": 197,
-        "sha1": "9d2b3693ee8ce866ce05f33132f9139d8effe113",
-        "fingerprint": "4e13ff2ee8b1291acebd8a25322f308a",
-        "original_path": "coalib/bearlib/languages/definitions/python3.coalang",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/parsing/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 167,
-        "sha1": "1d6888393b8f538d29e3a058f308ff1f62fb72b2",
-        "fingerprint": "6aa21401c620cd8a33708dc97662c0c1",
-        "original_path": "coalib/parsing/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/settings/SectionFilling.py",
-        "type": "file",
-        "name": "SectionFilling.py",
-        "size": 3942,
-        "sha1": "854be00b87187803b6d311592d2842b3ba07be0b",
-        "fingerprint": "931e5295cb2424b587c042a0173295ea",
-        "original_path": "coalib/settings/SectionFilling.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/bearlib/languages/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 86,
-        "sha1": "b5fd238b55022311cd4fcaa2635bf058a7a78660",
-        "fingerprint": "6895b8636b8cc861c715c67c7af609bb",
-        "original_path": "coalib/bearlib/languages/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/bears/GlobalBear.py",
-        "type": "file",
-        "name": "GlobalBear.py",
-        "size": 1175,
-        "sha1": "5bcacff0da623782a10a06c372068f8c75a0f1c8",
-        "fingerprint": "5d34b77657e13d2ce4c1004619cd5c53",
-        "original_path": "coalib/bears/GlobalBear.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/coala.py",
-        "type": "file",
-        "name": "coala.py",
-        "size": 2836,
-        "sha1": "2225cfa2e760261b02d5eb37a3d318c0b4fb2fb1",
-        "fingerprint": "38a5e5aa22cdc5e33276eda275afaf6d",
-        "original_path": "coalib/coala.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/results/SourcePosition.py",
-        "type": "file",
-        "name": "SourcePosition.py",
-        "size": 1287,
-        "sha1": "fa17682d4e15e32e3f1b72c21e9232f9fb35a2f7",
-        "fingerprint": "15484bc17569a8ed9cc166afee8773b4",
-        "original_path": "coalib/results/SourcePosition.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/processes/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 0,
-        "sha1": null,
-        "fingerprint": null,
-        "original_path": "coalib/processes/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/results/ResultFilter.py",
-        "type": "file",
-        "name": "ResultFilter.py",
-        "size": 9630,
-        "sha1": "09a01787b0ecb8a6eebaafd072a8e7ca1c44f61c",
-        "fingerprint": "2b3cabb5ebde850faffb0e4798c61846",
-        "original_path": "coalib/results/ResultFilter.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/misc/BuildManPage.py",
-        "type": "file",
-        "name": "BuildManPage.py",
-        "size": 7292,
-        "sha1": "0ce03b82db96c5789f673e318e1d1946b6f04c4a",
-        "fingerprint": "6399f8b7db683e427e9d62c09cfccf17",
-        "original_path": "coalib/misc/BuildManPage.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/bearlib/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 211,
-        "sha1": "4cef36542f76d618ef6d258b2f1adc90e5d545da",
-        "fingerprint": "7688102f13925981f20810ae3e480c5f",
-        "original_path": "coalib/bearlib/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/misc/Shell.py",
-        "type": "file",
-        "name": "Shell.py",
-        "size": 4344,
-        "sha1": "6f5afaddd0b0587b9c5da4c9876c7c02b58f3471",
-        "fingerprint": "57f8a830d355efc59ab2cef672b2c896",
-        "original_path": "coalib/misc/Shell.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/coala_main.py",
-        "type": "file",
-        "name": "coala_main.py",
-        "size": 5013,
-        "sha1": "1d92b5257fded9b408a579c0fc13d83f0c455c86",
-        "fingerprint": "78f4dc871b1e370185e021193b3734cd",
-        "original_path": "coalib/coala_main.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/settings/Setting.py",
-        "type": "file",
-        "name": "Setting.py",
-        "size": 8402,
-        "sha1": "a11855347f6d2d12495e265834ef611d254f645c",
-        "fingerprint": "4a1019a9f5b4d802aeca7d2de7d3d0f9",
-        "original_path": "coalib/settings/Setting.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/bearlib/spacing/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 0,
-        "sha1": null,
-        "fingerprint": null,
-        "original_path": "coalib/bearlib/spacing/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/misc/DictUtilities.py",
-        "type": "file",
-        "name": "DictUtilities.py",
-        "size": 1355,
-        "sha1": "36522522c930d05c37f791fa08eaf3ebe50b65d5",
-        "fingerprint": "1036a2201d37c7c380155ec265f387e1",
-        "original_path": "coalib/misc/DictUtilities.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/default_coafile",
-        "type": "file",
-        "name": "default_coafile",
-        "size": 0,
-        "sha1": null,
-        "fingerprint": null,
-        "original_path": "coalib/default_coafile",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/bearlib/languages/LanguageDefinition.py",
-        "type": "file",
-        "name": "LanguageDefinition.py",
-        "size": 1438,
-        "sha1": "2536c0a6d2093e584da16f29873661c44f5e118e",
-        "fingerprint": "b786be2e33146975211d2015109cffc0",
-        "original_path": "coalib/bearlib/languages/LanguageDefinition.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/parsing/StringProcessing/Core.py",
-        "type": "file",
-        "name": "Core.py",
-        "size": 21420,
-        "sha1": "9bc4ee2efb4030a110eee77aa93340bcc523d142",
-        "fingerprint": "43722cfbf2f6d56ca294653b1e16af80",
-        "original_path": "coalib/parsing/StringProcessing/Core.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/bearlib/languages/documentation/DocstyleDefinition.py",
-        "type": "file",
-        "name": "DocstyleDefinition.py",
-        "size": 5815,
-        "sha1": "2f7a7bf51563d4db2ca4e26a5564fc70a22af029",
-        "fingerprint": "3afc41add5d7163401300fa7a0dc5544",
-        "original_path": "coalib/bearlib/languages/documentation/DocstyleDefinition.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/bearlib/languages/documentation/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 131,
-        "sha1": "eb5fe0a696ffb1729c1d59ca79c7c8c41294b6a5",
-        "fingerprint": "4efe1f6ffd1ceb9b41961ab0345dd9f8",
-        "original_path": "coalib/bearlib/languages/documentation/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/bearlib/languages/documentation/DocumentationExtraction.py",
-        "type": "file",
-        "name": "DocumentationExtraction.py",
-        "size": 11244,
-        "sha1": "7795573d96ef91b34a4cbed6fb9ed2b2a6c48834",
-        "fingerprint": "90a8d09d58849706b215f5e6f051f985",
-        "original_path": "coalib/bearlib/languages/documentation/DocumentationExtraction.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/bears/Bear.py",
-        "type": "file",
-        "name": "Bear.py",
-        "size": 13931,
-        "sha1": "2a8383187dd5217c18741bbb979d9d513abc4f9f",
-        "fingerprint": "a658793a6fed424181d6043a3ad23a2f",
-        "original_path": "coalib/bears/Bear.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/results/RESULT_SEVERITY.py",
-        "type": "file",
-        "name": "RESULT_SEVERITY.py",
-        "size": 335,
-        "sha1": "f62c69c57609c4b9f11e3ac4eef091f2aed21884",
-        "fingerprint": "74c4d3e1d03194a6230ce4fc924188b6",
-        "original_path": "coalib/results/RESULT_SEVERITY.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/bearlib/abstractions/Linter.py",
-        "type": "file",
-        "name": "Linter.py",
-        "size": 31946,
-        "sha1": "6ca88650c2d066a005333598736ab715b315be59",
-        "fingerprint": "2ae7c5cb283137770c7448ed2f8a797f",
-        "original_path": "coalib/bearlib/abstractions/Linter.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/parsing/CliParsing.py",
-        "type": "file",
-        "name": "CliParsing.py",
-        "size": 4608,
-        "sha1": "ac872955d8f7077981dd9ffb0a862dde77b6a105",
-        "fingerprint": "2bcd40951316352148196b2a8a63499a",
-        "original_path": "coalib/parsing/CliParsing.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/parsing/StringProcessing/Match.py",
-        "type": "file",
-        "name": "Match.py",
-        "size": 1541,
-        "sha1": "a1a68427837dd34b3bc40e4c716238da4b206efa",
-        "fingerprint": "0c2a9e5e8470895acfa04d7607158532",
-        "original_path": "coalib/parsing/StringProcessing/Match.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/results/SourceRange.py",
-        "type": "file",
-        "name": "SourceRange.py",
-        "size": 4790,
-        "sha1": "f8cfce36f2ad4964fca37e16193330dd541069e7",
-        "fingerprint": "0d7328418e1c1831e9f91b2787b52aee",
-        "original_path": "coalib/results/SourceRange.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/collecting/Dependencies.py",
-        "type": "file",
-        "name": "Dependencies.py",
-        "size": 1313,
-        "sha1": "953c7ba0324c83d7b07e83735e3e2c8c8f5e1acd",
-        "fingerprint": "4b55b4d2458f5aa4b389198549352cd2",
-        "original_path": "coalib/collecting/Dependencies.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/bearlib/spacing/SpacingHelper.py",
-        "type": "file",
-        "name": "SpacingHelper.py",
-        "size": 3809,
-        "sha1": "33ccbfc6383e8559bec62c7f43a39e2022c427a2",
-        "fingerprint": "159b24c21e6bda7e3d8c079f52b8be0c",
-        "original_path": "coalib/bearlib/spacing/SpacingHelper.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/bears/BEAR_KIND.py",
-        "type": "file",
-        "name": "BEAR_KIND.py",
-        "size": 71,
-        "sha1": "1dedd6553debf266c2640412be83ce83f790ee5a",
-        "fingerprint": "04e4c4c01c84756e028240c8400c419e",
-        "original_path": "coalib/bears/BEAR_KIND.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/coala_json.py",
-        "type": "file",
-        "name": "coala_json.py",
-        "size": 2137,
-        "sha1": "cd70a96cbed7fa84704a21f777490e5b7edf671e",
-        "fingerprint": "99bfb5ea528ec5b7b220e9a85893cfa7",
-        "original_path": "coalib/coala_json.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/bearlib/languages/documentation/DocumentationComment.py",
-        "type": "file",
-        "name": "DocumentationComment.py",
-        "size": 5150,
-        "sha1": "505a3cf1cff6b8550cc45f3bf8989c27c81e4415",
-        "fingerprint": "0a24c66a1c169d373491cfa93cd2ae10",
-        "original_path": "coalib/bearlib/languages/documentation/DocumentationComment.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/results/result_actions/PrintDebugMessageAction.py",
-        "type": "file",
-        "name": "PrintDebugMessageAction.py",
-        "size": 511,
-        "sha1": "986c5f904a0ee78c85a71d96b6621e85e1a9a8fd",
-        "fingerprint": "356aafc67c4ac74f425c679fe2901cc6",
-        "original_path": "coalib/results/result_actions/PrintDebugMessageAction.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/parsing/ConfParser.py",
-        "type": "file",
-        "name": "ConfParser.py",
-        "size": 4972,
-        "sha1": "1d22cefa6947824fd1de7ebb24afc2e619b3a4e6",
-        "fingerprint": "2fb6e0b4edcbc8e4ab45ab6e88e8689c",
-        "original_path": "coalib/parsing/ConfParser.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/bearlib/languages/definitions/cpp.coalang",
-        "type": "file",
-        "name": "cpp.coalang",
-        "size": 1057,
-        "sha1": "eeae9b0805d0a73ec9776ca22b167b4c35fbd9d4",
-        "fingerprint": "4c81f332400813355093b2419a3219a5",
-        "original_path": "coalib/bearlib/languages/definitions/cpp.coalang",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/parsing/StringProcessing/InBetweenMatch.py",
-        "type": "file",
-        "name": "InBetweenMatch.py",
-        "size": 2120,
-        "sha1": "8a30603a995eb98fdb520b6ea1c8ea87be369c59",
-        "fingerprint": "24530d0b9ff122277ff62d13250ecc8b",
-        "original_path": "coalib/parsing/StringProcessing/InBetweenMatch.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/processes/communication/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 0,
-        "sha1": null,
-        "fingerprint": null,
-        "original_path": "coalib/processes/communication/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/bearlib/languages/documentation/default.coalang",
-        "type": "file",
-        "name": "default.coalang",
-        "size": 68,
-        "sha1": "7f0974af6b1eaae9bae4c6da6cff997d8e30391b",
-        "fingerprint": "29648818f15009000691631ec22a1e20",
-        "original_path": "coalib/bearlib/languages/documentation/default.coalang",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/output/JSONEncoder.py",
-        "type": "file",
-        "name": "JSONEncoder.py",
-        "size": 1256,
-        "sha1": "26db9936440aa8422b581950c42d19f633c12923",
-        "fingerprint": "a62ae43d2cac7ee7dc5ea4b93b9ded21",
-        "original_path": "coalib/output/JSONEncoder.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/output/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 0,
-        "sha1": null,
-        "fingerprint": null,
-        "original_path": "coalib/output/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/output/dbus/DbusServer.py",
-        "type": "file",
-        "name": "DbusServer.py",
-        "size": 5769,
-        "sha1": "d16266087223a9556f6e4781e69de390068dfe06",
-        "fingerprint": "b000c2408994a39d58cfbd1d6344e536",
-        "original_path": "coalib/output/dbus/DbusServer.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/coala_ci.py",
-        "type": "file",
-        "name": "coala_ci.py",
-        "size": 1268,
-        "sha1": "f2c064700aa6d83522cbe7eeef5f3fd47a0739d4",
-        "fingerprint": "98a9edaa529dc523723eedb665b7efaf",
-        "original_path": "coalib/coala_ci.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/settings/ConfigurationGathering.py",
-        "type": "file",
-        "name": "ConfigurationGathering.py",
-        "size": 12826,
-        "sha1": "d7ad37ad4817fdeda51adaab56fdb5b30398caaa",
-        "fingerprint": "1b28a404cb47a335877b71cf0ad4e9cd",
-        "original_path": "coalib/settings/ConfigurationGathering.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/collecting/Importers.py",
-        "type": "file",
-        "name": "Importers.py",
-        "size": 6525,
-        "sha1": "481e110633ccda469d2fee25b3a7149f1400d40d",
-        "fingerprint": "c0c3abc539335102321bcb8b417724ef",
-        "original_path": "coalib/collecting/Importers.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/results/AbsolutePosition.py",
-        "type": "file",
-        "name": "AbsolutePosition.py",
-        "size": 2124,
-        "sha1": "b71dbe990853bbef5e142afdd3e74e63aa50e5f4",
-        "fingerprint": "9eec100f2079940204c3463cb6e414f2",
-        "original_path": "coalib/results/AbsolutePosition.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/results/TextPosition.py",
-        "type": "file",
-        "name": "TextPosition.py",
-        "size": 1086,
-        "sha1": "839fb63d8993f0e231db80565c15945011c67cd4",
-        "fingerprint": "0c254f646100e021dca548b785baa224",
-        "original_path": "coalib/results/TextPosition.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/parsing/LineParser.py",
-        "type": "file",
-        "name": "LineParser.py",
-        "size": 6440,
-        "sha1": "05418a678e5ffec3f04117abf2007acbde2be125",
-        "fingerprint": "4959f9ab0bdd2db376b0c37619fe41d6",
-        "original_path": "coalib/parsing/LineParser.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/processes/BearRunning.py",
-        "type": "file",
-        "name": "BearRunning.py",
-        "size": 24041,
-        "sha1": "fabf0293e99224ee9ddbdd5f41acc4e7c7e5fdc5",
-        "fingerprint": "203314d87e007a0fea85a49889a2a0bf",
-        "original_path": "coalib/processes/BearRunning.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/results/result_actions/OpenEditorAction.py",
-        "type": "file",
-        "name": "OpenEditorAction.py",
-        "size": 2125,
-        "sha1": "e0d186c0b4c6fcc6de680748ddae536e0ea08db3",
-        "fingerprint": "8965a1b3265a811555f9e6f686de63a6",
-        "original_path": "coalib/results/result_actions/OpenEditorAction.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/misc/CachingUtilities.py",
-        "type": "file",
-        "name": "CachingUtilities.py",
-        "size": 6502,
-        "sha1": "81c78d59bff4c19ad188183530ebd3758b247d40",
-        "fingerprint": "7ac5987404de6c98ecbc7180e8633ebc",
-        "original_path": "coalib/misc/CachingUtilities.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/bearlib/abstractions/Lint.py",
-        "type": "file",
-        "name": "Lint.py",
-        "size": 15710,
-        "sha1": "b430f0c735ca261779204a76e88658c21a6e8210",
-        "fingerprint": "b0e3971ba8512f7e537c6ccf699b5ab2",
-        "original_path": "coalib/bearlib/abstractions/Lint.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/misc/MutableValue.py",
-        "type": "file",
-        "name": "MutableValue.py",
-        "size": 80,
-        "sha1": "4897a234c35f97cc6782289bd289f7b79962d292",
-        "fingerprint": "2ea13e761002738040a4a408074e2143",
-        "original_path": "coalib/misc/MutableValue.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/misc/Caching.py",
-        "type": "file",
-        "name": "Caching.py",
-        "size": 5382,
-        "sha1": "cf5c71f064d91bec125742b8eb63b1bef9725024",
-        "fingerprint": "4679ca1685029570ad3391ab2d6951d1",
-        "original_path": "coalib/misc/Caching.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/parsing/StringProcessing/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 1082,
-        "sha1": "fbd024543ce29cc0fedc6ad396a10d64a7a61128",
-        "fingerprint": "344d7f56111c282cbcde92929e63e141",
-        "original_path": "coalib/parsing/StringProcessing/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/output/dbus/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 561,
-        "sha1": "727f8b13d15f98f72c6dc45aaa76ce1d209a6b90",
-        "fingerprint": "13b5a7360a43dd189f681c5ea9a850ae",
-        "original_path": "coalib/output/dbus/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/results/TextRange.py",
-        "type": "file",
-        "name": "TextRange.py",
-        "size": 4199,
-        "sha1": "48b2fcf56ef62729ff1a673f81705a0b44ea22da",
-        "fingerprint": "cf414f759c8dcb87bedc697fc73d00ea",
-        "original_path": "coalib/results/TextRange.py",
+        "name": "PipRequirement.py",
+        "size": 847,
+        "sha1": "2de354930248f786449c8a1993af9f3564c6afd3",
+        "fingerprint": "1130f2506e1a4420c209dbc61a285300",
+        "original_path": "coalib/bears/requirements/PipRequirement.py",
         "licenses": [],
         "copyrights": []
       }
@@ -3537,431 +3027,6 @@
       "score": 0,
       "new": null,
       "old": {
-        "path": "coalib/bearlib/languages/documentation/doxygen.coalang",
-        "type": "file",
-        "name": "doxygen.coalang",
-        "size": 1215,
-        "sha1": "df1da2a93331aa0672bc7810b88aaedd83d6b3f4",
-        "fingerprint": "f047b03a7bb083b348ba4b9ab6bc2a38",
-        "original_path": "coalib/bearlib/languages/documentation/doxygen.coalang",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/bears/requirements/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 0,
-        "sha1": null,
-        "fingerprint": null,
-        "original_path": "coalib/bears/requirements/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/bears/requirements/PackageRequirement.py",
-        "type": "file",
-        "name": "PackageRequirement.py",
-        "size": 4261,
-        "sha1": "52be29490537645a298a16020c53c7fa8607b0e8",
-        "fingerprint": "8726332c80c5512cb636c877ebb9d1b1",
-        "original_path": "coalib/bears/requirements/PackageRequirement.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/processes/LogPrinterThread.py",
-        "type": "file",
-        "name": "LogPrinterThread.py",
-        "size": 688,
-        "sha1": "8fcd1e4e74eec575a4ee1d15d3b28c06e26c26da",
-        "fingerprint": "f0d01ba11529060bfb94e1f0e3245155",
-        "original_path": "coalib/processes/LogPrinterThread.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/misc/Enum.py",
-        "type": "file",
-        "name": "Enum.py",
-        "size": 270,
-        "sha1": "77579568fabc8ccb3d3e9476fea5f01f862066d9",
-        "fingerprint": "10eb976a00693bd4b34767452d4fda24",
-        "original_path": "coalib/misc/Enum.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/results/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 0,
-        "sha1": null,
-        "fingerprint": null,
-        "original_path": "coalib/results/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/misc/ContextManagers.py",
-        "type": "file",
-        "name": "ContextManagers.py",
-        "size": 7320,
-        "sha1": "2f96b9fafe873fbf4fe728ec3bee297b76b23ad3",
-        "fingerprint": "59ae0f94aaf016681f9b4e334b93d871",
-        "original_path": "coalib/misc/ContextManagers.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/output/printers/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 269,
-        "sha1": "5d2e282a3771dc975bef6a32cf338ad62500f421",
-        "fingerprint": "6119f362803a91b51636b9a32efe15e7",
-        "original_path": "coalib/output/printers/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/output/dbus/BuildDbusService.py",
-        "type": "file",
-        "name": "BuildDbusService.py",
-        "size": 1411,
-        "sha1": "50d4a97f5b22a668fa6b32a5439d895395e35ed8",
-        "fingerprint": "f396d383c00c04c29308444c18fa4b61",
-        "original_path": "coalib/output/dbus/BuildDbusService.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/output/dbus/DbusDocument.py",
-        "type": "file",
-        "name": "DbusDocument.py",
-        "size": 6938,
-        "sha1": "c785c58df4bb36e11204298b08fd11706fec0537",
-        "fingerprint": "76b6e667cc3be1d65dfbb3ce78a6708b",
-        "original_path": "coalib/output/dbus/DbusDocument.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/output/printers/ListLogPrinter.py",
-        "type": "file",
-        "name": "ListLogPrinter.py",
-        "size": 1002,
-        "sha1": "1e041b0f70a6611482b8cc87729a454360f6c5a5",
-        "fingerprint": "1849b95ccea730fb04c10a92a28638a1",
-        "original_path": "coalib/output/printers/ListLogPrinter.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/processes/communication/LogMessage.py",
-        "type": "file",
-        "name": "LogMessage.py",
-        "size": 1620,
-        "sha1": "622d5ff6d91438c84665e33499fc57bc2350bdd1",
-        "fingerprint": "88ab42e33fb80649506f46ac63b4bdc0",
-        "original_path": "coalib/processes/communication/LogMessage.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/misc/StringConverter.py",
-        "type": "file",
-        "name": "StringConverter.py",
-        "size": 5054,
-        "sha1": "c631950e218cab444d1493617a65a12b00364881",
-        "fingerprint": "ea9a8d1344c48ce23d4fb5e986e50a88",
-        "original_path": "coalib/misc/StringConverter.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/parsing/StringProcessing/Filters.py",
-        "type": "file",
-        "name": "Filters.py",
-        "size": 1331,
-        "sha1": "d6c829ce09c42b1f32c80427656ecc2571ba86a9",
-        "fingerprint": "a60f7b72ef38d44cb9ed9093571f9043",
-        "original_path": "coalib/parsing/StringProcessing/Filters.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/misc/Annotations.py",
-        "type": "file",
-        "name": "Annotations.py",
-        "size": 1580,
-        "sha1": "cdb9d2308606ad94a071ded80d13b94be0ad5edf",
-        "fingerprint": "70870fe418fa0945500072b73873eb0e",
-        "original_path": "coalib/misc/Annotations.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/results/Result.py",
-        "type": "file",
-        "name": "Result.py",
-        "size": 8637,
-        "sha1": "52192b2cd2a12bd23a26ff48ea20a3675f674ca3",
-        "fingerprint": "0f906ab5d4acc96d80be2b04f6f67f63",
-        "original_path": "coalib/results/Result.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/output/dbus/DbusApp.py",
-        "type": "file",
-        "name": "DbusApp.py",
-        "size": 1509,
-        "sha1": "3549f039b292fbefdf45c2c487b3695daaec594f",
-        "fingerprint": "3315270d0f17234d9838f3542645e550",
-        "original_path": "coalib/output/dbus/DbusApp.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/results/result_actions/ShowPatchAction.py",
-        "type": "file",
-        "name": "ShowPatchAction.py",
-        "size": 4291,
-        "sha1": "676d5e5de8850d9fbf10cf74af84148c17da9734",
-        "fingerprint": "2b714700258b20a7d93480c64620011e",
-        "original_path": "coalib/results/result_actions/ShowPatchAction.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/bearlib/languages/definitions/c.coalang",
-        "type": "file",
-        "name": "c.coalang",
-        "size": 568,
-        "sha1": "a6f2eeb3d4a7a983bdec457cf438bebc5e96d429",
-        "fingerprint": "8d91eb5c609d76bddaf1c2443983596c",
-        "original_path": "coalib/bearlib/languages/definitions/c.coalang",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/bearlib/abstractions/ExternalBearWrap.py",
-        "type": "file",
-        "name": "ExternalBearWrap.py",
-        "size": 7867,
-        "sha1": "161505af88d7b664904da509f91ac9ac2b3cd742",
-        "fingerprint": "b8c47183ea595f200dab02d485b6d16c",
-        "original_path": "coalib/bearlib/abstractions/ExternalBearWrap.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/output/printers/LOG_LEVEL.py",
-        "type": "file",
-        "name": "LOG_LEVEL.py",
-        "size": 272,
-        "sha1": "a57241f7f6f906db3065b7d24bed00044defcd0f",
-        "fingerprint": "50644ff29da782e83e3c50c41a37fb88",
-        "original_path": "coalib/output/printers/LOG_LEVEL.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/parsing/Globbing.py",
-        "type": "file",
-        "name": "Globbing.py",
-        "size": 13150,
-        "sha1": "f86d5aad9ba6926068592a740d3ae2f2d416d547",
-        "fingerprint": "fc950f722b42ab2ebfd2830debf832b3",
-        "original_path": "coalib/parsing/Globbing.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/bears/LocalBear.py",
-        "type": "file",
-        "name": "LocalBear.py",
-        "size": 1523,
-        "sha1": "171aab7341ee0465c3353f651108e1ab8816778e",
-        "fingerprint": "566ef2ad89495fb6338f0bb5022d9f75",
-        "original_path": "coalib/bears/LocalBear.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/settings/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 0,
-        "sha1": null,
-        "fingerprint": null,
-        "original_path": "coalib/settings/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/parsing/DefaultArgParser.py",
-        "type": "file",
-        "name": "DefaultArgParser.py",
-        "size": 7803,
-        "sha1": "2dcf68c5179bc7f7d0074166bfadccf636c429b1",
-        "fingerprint": "51a1006471d9a6c3491834a129ea6038",
-        "original_path": "coalib/parsing/DefaultArgParser.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
         "path": "coalib/collecting/Collectors.py",
         "type": "file",
         "name": "Collectors.py",
@@ -3979,13 +3044,13 @@
       "score": 0,
       "new": null,
       "old": {
-        "path": "coalib/results/LineDiff.py",
+        "path": "coalib/collecting/Dependencies.py",
         "type": "file",
-        "name": "LineDiff.py",
-        "size": 2423,
-        "sha1": "984319005dc3629a94a9e6e32d36efbddef386f0",
-        "fingerprint": "c03f9da2151011896d799befb01547a6",
-        "original_path": "coalib/results/LineDiff.py",
+        "name": "Dependencies.py",
+        "size": 1313,
+        "sha1": "953c7ba0324c83d7b07e83735e3e2c8c8f5e1acd",
+        "fingerprint": "4b55b4d2458f5aa4b389198549352cd2",
+        "original_path": "coalib/collecting/Dependencies.py",
         "licenses": [],
         "copyrights": []
       }
@@ -3996,64 +3061,13 @@
       "score": 0,
       "new": null,
       "old": {
-        "path": "coalib/results/result_actions/PrintMoreInfoAction.py",
+        "path": "coalib/collecting/Importers.py",
         "type": "file",
-        "name": "PrintMoreInfoAction.py",
-        "size": 530,
-        "sha1": "b81493f315271c5d357ba2b5f1a723cef2a070f4",
-        "fingerprint": "2f7adfe45862d150c35077ebc2b02b76",
-        "original_path": "coalib/results/result_actions/PrintMoreInfoAction.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/bears/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 0,
-        "sha1": null,
-        "fingerprint": null,
-        "original_path": "coalib/bears/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/misc/Future.py",
-        "type": "file",
-        "name": "Future.py",
-        "size": 3748,
-        "sha1": "c07134749c576cb2dbf33be37951e01f96763a25",
-        "fingerprint": "e124dbc2b4dbc3757b8bfab1722e8280",
-        "original_path": "coalib/misc/Future.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "removed",
-      "factors": [],
-      "score": 0,
-      "new": null,
-      "old": {
-        "path": "coalib/output/Interactions.py",
-        "type": "file",
-        "name": "Interactions.py",
-        "size": 1191,
-        "sha1": "cea2ad6687ba74016a94e4077b6a691220acae7f",
-        "fingerprint": "29b16f5c4923844099fb15e14aa28176",
-        "original_path": "coalib/output/Interactions.py",
+        "name": "Importers.py",
+        "size": 6525,
+        "sha1": "481e110633ccda469d2fee25b3a7149f1400d40d",
+        "fingerprint": "c0c3abc539335102321bcb8b417724ef",
+        "original_path": "coalib/collecting/Importers.py",
         "licenses": [],
         "copyrights": []
       }
@@ -4081,13 +3095,13 @@
       "score": 0,
       "new": null,
       "old": {
-        "path": "coalib/bearlib/abstractions/__init__.py",
+        "path": "coalib/misc/Annotations.py",
         "type": "file",
-        "name": "__init__.py",
-        "size": 110,
-        "sha1": "7470ffdc8bb4a378866338e5ab0e14789b8dcb6a",
-        "fingerprint": "155828fa383550138b34f6cef327030c",
-        "original_path": "coalib/bearlib/abstractions/__init__.py",
+        "name": "Annotations.py",
+        "size": 1580,
+        "sha1": "cdb9d2308606ad94a071ded80d13b94be0ad5edf",
+        "fingerprint": "70870fe418fa0945500072b73873eb0e",
+        "original_path": "coalib/misc/Annotations.py",
         "licenses": [],
         "copyrights": []
       }
@@ -4098,13 +3112,13 @@
       "score": 0,
       "new": null,
       "old": {
-        "path": "coalib/results/Diff.py",
+        "path": "coalib/misc/BuildManPage.py",
         "type": "file",
-        "name": "Diff.py",
-        "size": 13134,
-        "sha1": "8d2bdab0c8df913052df348a8db2795a0bfacb95",
-        "fingerprint": "a3749436c476a393ac4ab48d26d38c46",
-        "original_path": "coalib/results/Diff.py",
+        "name": "BuildManPage.py",
+        "size": 7292,
+        "sha1": "0ce03b82db96c5789f673e318e1d1946b6f04c4a",
+        "fingerprint": "6399f8b7db683e427e9d62c09cfccf17",
+        "original_path": "coalib/misc/BuildManPage.py",
         "licenses": [],
         "copyrights": []
       }
@@ -4115,13 +3129,13 @@
       "score": 0,
       "new": null,
       "old": {
-        "path": "coalib/results/result_actions/__init__.py",
+        "path": "coalib/misc/Caching.py",
         "type": "file",
-        "name": "__init__.py",
-        "size": 145,
-        "sha1": "9db16072266575f9881dfbbafecdf8ab7a14cdb0",
-        "fingerprint": "20ca18b5604a47298a558b045295210b",
-        "original_path": "coalib/results/result_actions/__init__.py",
+        "name": "Caching.py",
+        "size": 5382,
+        "sha1": "cf5c71f064d91bec125742b8eb63b1bef9725024",
+        "fingerprint": "4679ca1685029570ad3391ab2d6951d1",
+        "original_path": "coalib/misc/Caching.py",
         "licenses": [],
         "copyrights": []
       }
@@ -4132,13 +3146,13 @@
       "score": 0,
       "new": null,
       "old": {
-        "path": "coalib/results/HiddenResult.py",
+        "path": "coalib/misc/CachingUtilities.py",
         "type": "file",
-        "name": "HiddenResult.py",
-        "size": 639,
-        "sha1": "6e345fb1ba8824d211f5cf6de9bf92dd9477a721",
-        "fingerprint": "b91b4a4702a7a803f9696ee71735e82e",
-        "original_path": "coalib/results/HiddenResult.py",
+        "name": "CachingUtilities.py",
+        "size": 6502,
+        "sha1": "81c78d59bff4c19ad188183530ebd3758b247d40",
+        "fingerprint": "7ac5987404de6c98ecbc7180e8633ebc",
+        "original_path": "coalib/misc/CachingUtilities.py",
         "licenses": [],
         "copyrights": []
       }
@@ -4149,13 +3163,13 @@
       "score": 0,
       "new": null,
       "old": {
-        "path": "coalib/VERSION",
+        "path": "coalib/misc/ContextManagers.py",
         "type": "file",
-        "name": "VERSION",
-        "size": 6,
-        "sha1": "8606c087f8b6f1684acd81984a1b1723c35f95c1",
-        "fingerprint": "1f9fea2088b09fd355ce4bac1ba93ee9",
-        "original_path": "coalib/VERSION",
+        "name": "ContextManagers.py",
+        "size": 7320,
+        "sha1": "2f96b9fafe873fbf4fe728ec3bee297b76b23ad3",
+        "fingerprint": "59ae0f94aaf016681f9b4e334b93d871",
+        "original_path": "coalib/misc/ContextManagers.py",
         "licenses": [],
         "copyrights": []
       }
@@ -4166,13 +3180,30 @@
       "score": 0,
       "new": null,
       "old": {
-        "path": "coalib/bearlib/languages/definitions/__init__.py",
+        "path": "coalib/misc/DictUtilities.py",
         "type": "file",
-        "name": "__init__.py",
-        "size": 341,
-        "sha1": "87d64b589629f8347219295d2ef4225a5c8328c9",
-        "fingerprint": "be9d7000b7bbecae1169b75939c8e4a9",
-        "original_path": "coalib/bearlib/languages/definitions/__init__.py",
+        "name": "DictUtilities.py",
+        "size": 1355,
+        "sha1": "36522522c930d05c37f791fa08eaf3ebe50b65d5",
+        "fingerprint": "1036a2201d37c7c380155ec265f387e1",
+        "original_path": "coalib/misc/DictUtilities.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/misc/Enum.py",
+        "type": "file",
+        "name": "Enum.py",
+        "size": 270,
+        "sha1": "77579568fabc8ccb3d3e9476fea5f01f862066d9",
+        "fingerprint": "10eb976a00693bd4b34767452d4fda24",
+        "original_path": "coalib/misc/Enum.py",
         "licenses": [],
         "copyrights": []
       }
@@ -4200,13 +3231,13 @@
       "score": 0,
       "new": null,
       "old": {
-        "path": "coalib/bearlib/naming_conventions/__init__.py",
+        "path": "coalib/misc/Future.py",
         "type": "file",
-        "name": "__init__.py",
-        "size": 3507,
-        "sha1": "04c549b54d2b6eee40ac41e8e05d2cf48d7fd632",
-        "fingerprint": "7b59879d408150c78e4c5f5a2b057003",
-        "original_path": "coalib/bearlib/naming_conventions/__init__.py",
+        "name": "Future.py",
+        "size": 3748,
+        "sha1": "c07134749c576cb2dbf33be37951e01f96763a25",
+        "fingerprint": "e124dbc2b4dbc3757b8bfab1722e8280",
+        "original_path": "coalib/misc/Future.py",
         "licenses": [],
         "copyrights": []
       }
@@ -4217,13 +3248,251 @@
       "score": 0,
       "new": null,
       "old": {
-        "path": "coalib/results/result_actions/ApplyPatchAction.py",
+        "path": "coalib/misc/MutableValue.py",
         "type": "file",
-        "name": "ApplyPatchAction.py",
-        "size": 2282,
-        "sha1": "cbfeed295786c489aa9395886dfd2d19671af22b",
-        "fingerprint": "f32988aa9d6beda19e3c839d0752407e",
-        "original_path": "coalib/results/result_actions/ApplyPatchAction.py",
+        "name": "MutableValue.py",
+        "size": 80,
+        "sha1": "4897a234c35f97cc6782289bd289f7b79962d292",
+        "fingerprint": "2ea13e761002738040a4a408074e2143",
+        "original_path": "coalib/misc/MutableValue.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/misc/Shell.py",
+        "type": "file",
+        "name": "Shell.py",
+        "size": 4344,
+        "sha1": "6f5afaddd0b0587b9c5da4c9876c7c02b58f3471",
+        "fingerprint": "57f8a830d355efc59ab2cef672b2c896",
+        "original_path": "coalib/misc/Shell.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/misc/StringConverter.py",
+        "type": "file",
+        "name": "StringConverter.py",
+        "size": 5054,
+        "sha1": "c631950e218cab444d1493617a65a12b00364881",
+        "fingerprint": "ea9a8d1344c48ce23d4fb5e986e50a88",
+        "original_path": "coalib/misc/StringConverter.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/output/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 0,
+        "sha1": null,
+        "fingerprint": null,
+        "original_path": "coalib/output/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/output/ConfWriter.py",
+        "type": "file",
+        "name": "ConfWriter.py",
+        "size": 4015,
+        "sha1": "2ae75d42ae63cda2ee490434b995c6a93ad4a8a0",
+        "fingerprint": "febc7e7552bfc1b5fdb8a5bf49cd02a0",
+        "original_path": "coalib/output/ConfWriter.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/output/Interactions.py",
+        "type": "file",
+        "name": "Interactions.py",
+        "size": 1191,
+        "sha1": "cea2ad6687ba74016a94e4077b6a691220acae7f",
+        "fingerprint": "29b16f5c4923844099fb15e14aa28176",
+        "original_path": "coalib/output/Interactions.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/output/JSONEncoder.py",
+        "type": "file",
+        "name": "JSONEncoder.py",
+        "size": 1256,
+        "sha1": "26db9936440aa8422b581950c42d19f633c12923",
+        "fingerprint": "a62ae43d2cac7ee7dc5ea4b93b9ded21",
+        "original_path": "coalib/output/JSONEncoder.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/output/dbus/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 561,
+        "sha1": "727f8b13d15f98f72c6dc45aaa76ce1d209a6b90",
+        "fingerprint": "13b5a7360a43dd189f681c5ea9a850ae",
+        "original_path": "coalib/output/dbus/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/output/dbus/BuildDbusService.py",
+        "type": "file",
+        "name": "BuildDbusService.py",
+        "size": 1411,
+        "sha1": "50d4a97f5b22a668fa6b32a5439d895395e35ed8",
+        "fingerprint": "f396d383c00c04c29308444c18fa4b61",
+        "original_path": "coalib/output/dbus/BuildDbusService.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/output/dbus/DbusApp.py",
+        "type": "file",
+        "name": "DbusApp.py",
+        "size": 1509,
+        "sha1": "3549f039b292fbefdf45c2c487b3695daaec594f",
+        "fingerprint": "3315270d0f17234d9838f3542645e550",
+        "original_path": "coalib/output/dbus/DbusApp.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/output/dbus/DbusDocument.py",
+        "type": "file",
+        "name": "DbusDocument.py",
+        "size": 6938,
+        "sha1": "c785c58df4bb36e11204298b08fd11706fec0537",
+        "fingerprint": "76b6e667cc3be1d65dfbb3ce78a6708b",
+        "original_path": "coalib/output/dbus/DbusDocument.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/output/dbus/DbusServer.py",
+        "type": "file",
+        "name": "DbusServer.py",
+        "size": 5769,
+        "sha1": "d16266087223a9556f6e4781e69de390068dfe06",
+        "fingerprint": "b000c2408994a39d58cfbd1d6344e536",
+        "original_path": "coalib/output/dbus/DbusServer.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/output/printers/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 269,
+        "sha1": "5d2e282a3771dc975bef6a32cf338ad62500f421",
+        "fingerprint": "6119f362803a91b51636b9a32efe15e7",
+        "original_path": "coalib/output/printers/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/output/printers/ListLogPrinter.py",
+        "type": "file",
+        "name": "ListLogPrinter.py",
+        "size": 1002,
+        "sha1": "1e041b0f70a6611482b8cc87729a454360f6c5a5",
+        "fingerprint": "1849b95ccea730fb04c10a92a28638a1",
+        "original_path": "coalib/output/printers/ListLogPrinter.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/output/printers/LOG_LEVEL.py",
+        "type": "file",
+        "name": "LOG_LEVEL.py",
+        "size": 272,
+        "sha1": "a57241f7f6f906db3065b7d24bed00044defcd0f",
+        "fingerprint": "50644ff29da782e83e3c50c41a37fb88",
+        "original_path": "coalib/output/printers/LOG_LEVEL.py",
         "licenses": [],
         "copyrights": []
       }
@@ -4251,6 +3520,261 @@
       "score": 0,
       "new": null,
       "old": {
+        "path": "coalib/parsing/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 167,
+        "sha1": "1d6888393b8f538d29e3a058f308ff1f62fb72b2",
+        "fingerprint": "6aa21401c620cd8a33708dc97662c0c1",
+        "original_path": "coalib/parsing/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/parsing/CliParsing.py",
+        "type": "file",
+        "name": "CliParsing.py",
+        "size": 4608,
+        "sha1": "ac872955d8f7077981dd9ffb0a862dde77b6a105",
+        "fingerprint": "2bcd40951316352148196b2a8a63499a",
+        "original_path": "coalib/parsing/CliParsing.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/parsing/ConfParser.py",
+        "type": "file",
+        "name": "ConfParser.py",
+        "size": 4972,
+        "sha1": "1d22cefa6947824fd1de7ebb24afc2e619b3a4e6",
+        "fingerprint": "2fb6e0b4edcbc8e4ab45ab6e88e8689c",
+        "original_path": "coalib/parsing/ConfParser.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/parsing/DefaultArgParser.py",
+        "type": "file",
+        "name": "DefaultArgParser.py",
+        "size": 7803,
+        "sha1": "2dcf68c5179bc7f7d0074166bfadccf636c429b1",
+        "fingerprint": "51a1006471d9a6c3491834a129ea6038",
+        "original_path": "coalib/parsing/DefaultArgParser.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/parsing/Globbing.py",
+        "type": "file",
+        "name": "Globbing.py",
+        "size": 13150,
+        "sha1": "f86d5aad9ba6926068592a740d3ae2f2d416d547",
+        "fingerprint": "fc950f722b42ab2ebfd2830debf832b3",
+        "original_path": "coalib/parsing/Globbing.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/parsing/LineParser.py",
+        "type": "file",
+        "name": "LineParser.py",
+        "size": 6440,
+        "sha1": "05418a678e5ffec3f04117abf2007acbde2be125",
+        "fingerprint": "4959f9ab0bdd2db376b0c37619fe41d6",
+        "original_path": "coalib/parsing/LineParser.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/parsing/StringProcessing/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 1082,
+        "sha1": "fbd024543ce29cc0fedc6ad396a10d64a7a61128",
+        "fingerprint": "344d7f56111c282cbcde92929e63e141",
+        "original_path": "coalib/parsing/StringProcessing/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/parsing/StringProcessing/Core.py",
+        "type": "file",
+        "name": "Core.py",
+        "size": 21420,
+        "sha1": "9bc4ee2efb4030a110eee77aa93340bcc523d142",
+        "fingerprint": "43722cfbf2f6d56ca294653b1e16af80",
+        "original_path": "coalib/parsing/StringProcessing/Core.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/parsing/StringProcessing/Filters.py",
+        "type": "file",
+        "name": "Filters.py",
+        "size": 1331,
+        "sha1": "d6c829ce09c42b1f32c80427656ecc2571ba86a9",
+        "fingerprint": "a60f7b72ef38d44cb9ed9093571f9043",
+        "original_path": "coalib/parsing/StringProcessing/Filters.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/parsing/StringProcessing/InBetweenMatch.py",
+        "type": "file",
+        "name": "InBetweenMatch.py",
+        "size": 2120,
+        "sha1": "8a30603a995eb98fdb520b6ea1c8ea87be369c59",
+        "fingerprint": "24530d0b9ff122277ff62d13250ecc8b",
+        "original_path": "coalib/parsing/StringProcessing/InBetweenMatch.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/parsing/StringProcessing/Match.py",
+        "type": "file",
+        "name": "Match.py",
+        "size": 1541,
+        "sha1": "a1a68427837dd34b3bc40e4c716238da4b206efa",
+        "fingerprint": "0c2a9e5e8470895acfa04d7607158532",
+        "original_path": "coalib/parsing/StringProcessing/Match.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/processes/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 0,
+        "sha1": null,
+        "fingerprint": null,
+        "original_path": "coalib/processes/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/processes/BearRunning.py",
+        "type": "file",
+        "name": "BearRunning.py",
+        "size": 24041,
+        "sha1": "fabf0293e99224ee9ddbdd5f41acc4e7c7e5fdc5",
+        "fingerprint": "203314d87e007a0fea85a49889a2a0bf",
+        "original_path": "coalib/processes/BearRunning.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/processes/CONTROL_ELEMENT.py",
+        "type": "file",
+        "name": "CONTROL_ELEMENT.py",
+        "size": 114,
+        "sha1": "8830c48ff828d0d93a1e37b83f411fa3b8eb238a",
+        "fingerprint": "84424c804091b01202101c0a229c93de",
+        "original_path": "coalib/processes/CONTROL_ELEMENT.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/processes/LogPrinterThread.py",
+        "type": "file",
+        "name": "LogPrinterThread.py",
+        "size": 688,
+        "sha1": "8fcd1e4e74eec575a4ee1d15d3b28c06e26c26da",
+        "fingerprint": "f0d01ba11529060bfb94e1f0e3245155",
+        "original_path": "coalib/processes/LogPrinterThread.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
         "path": "coalib/processes/Processing.py",
         "type": "file",
         "name": "Processing.py",
@@ -4258,6 +3782,482 @@
         "sha1": "c1059893aa69289d9f7bad3d73b5cfca32e379e1",
         "fingerprint": "8fa599d2554f91facc5f122828424e00",
         "original_path": "coalib/processes/Processing.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/processes/communication/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 0,
+        "sha1": null,
+        "fingerprint": null,
+        "original_path": "coalib/processes/communication/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/processes/communication/LogMessage.py",
+        "type": "file",
+        "name": "LogMessage.py",
+        "size": 1620,
+        "sha1": "622d5ff6d91438c84665e33499fc57bc2350bdd1",
+        "fingerprint": "88ab42e33fb80649506f46ac63b4bdc0",
+        "original_path": "coalib/processes/communication/LogMessage.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/results/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 0,
+        "sha1": null,
+        "fingerprint": null,
+        "original_path": "coalib/results/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/results/AbsolutePosition.py",
+        "type": "file",
+        "name": "AbsolutePosition.py",
+        "size": 2124,
+        "sha1": "b71dbe990853bbef5e142afdd3e74e63aa50e5f4",
+        "fingerprint": "9eec100f2079940204c3463cb6e414f2",
+        "original_path": "coalib/results/AbsolutePosition.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/results/Diff.py",
+        "type": "file",
+        "name": "Diff.py",
+        "size": 13134,
+        "sha1": "8d2bdab0c8df913052df348a8db2795a0bfacb95",
+        "fingerprint": "a3749436c476a393ac4ab48d26d38c46",
+        "original_path": "coalib/results/Diff.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/results/HiddenResult.py",
+        "type": "file",
+        "name": "HiddenResult.py",
+        "size": 639,
+        "sha1": "6e345fb1ba8824d211f5cf6de9bf92dd9477a721",
+        "fingerprint": "b91b4a4702a7a803f9696ee71735e82e",
+        "original_path": "coalib/results/HiddenResult.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/results/LineDiff.py",
+        "type": "file",
+        "name": "LineDiff.py",
+        "size": 2423,
+        "sha1": "984319005dc3629a94a9e6e32d36efbddef386f0",
+        "fingerprint": "c03f9da2151011896d799befb01547a6",
+        "original_path": "coalib/results/LineDiff.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/results/Result.py",
+        "type": "file",
+        "name": "Result.py",
+        "size": 8637,
+        "sha1": "52192b2cd2a12bd23a26ff48ea20a3675f674ca3",
+        "fingerprint": "0f906ab5d4acc96d80be2b04f6f67f63",
+        "original_path": "coalib/results/Result.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/results/RESULT_SEVERITY.py",
+        "type": "file",
+        "name": "RESULT_SEVERITY.py",
+        "size": 335,
+        "sha1": "f62c69c57609c4b9f11e3ac4eef091f2aed21884",
+        "fingerprint": "74c4d3e1d03194a6230ce4fc924188b6",
+        "original_path": "coalib/results/RESULT_SEVERITY.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/results/ResultFilter.py",
+        "type": "file",
+        "name": "ResultFilter.py",
+        "size": 9630,
+        "sha1": "09a01787b0ecb8a6eebaafd072a8e7ca1c44f61c",
+        "fingerprint": "2b3cabb5ebde850faffb0e4798c61846",
+        "original_path": "coalib/results/ResultFilter.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/results/SourcePosition.py",
+        "type": "file",
+        "name": "SourcePosition.py",
+        "size": 1287,
+        "sha1": "fa17682d4e15e32e3f1b72c21e9232f9fb35a2f7",
+        "fingerprint": "15484bc17569a8ed9cc166afee8773b4",
+        "original_path": "coalib/results/SourcePosition.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/results/SourceRange.py",
+        "type": "file",
+        "name": "SourceRange.py",
+        "size": 4790,
+        "sha1": "f8cfce36f2ad4964fca37e16193330dd541069e7",
+        "fingerprint": "0d7328418e1c1831e9f91b2787b52aee",
+        "original_path": "coalib/results/SourceRange.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/results/TextPosition.py",
+        "type": "file",
+        "name": "TextPosition.py",
+        "size": 1086,
+        "sha1": "839fb63d8993f0e231db80565c15945011c67cd4",
+        "fingerprint": "0c254f646100e021dca548b785baa224",
+        "original_path": "coalib/results/TextPosition.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/results/TextRange.py",
+        "type": "file",
+        "name": "TextRange.py",
+        "size": 4199,
+        "sha1": "48b2fcf56ef62729ff1a673f81705a0b44ea22da",
+        "fingerprint": "cf414f759c8dcb87bedc697fc73d00ea",
+        "original_path": "coalib/results/TextRange.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/results/result_actions/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 145,
+        "sha1": "9db16072266575f9881dfbbafecdf8ab7a14cdb0",
+        "fingerprint": "20ca18b5604a47298a558b045295210b",
+        "original_path": "coalib/results/result_actions/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/results/result_actions/ApplyPatchAction.py",
+        "type": "file",
+        "name": "ApplyPatchAction.py",
+        "size": 2282,
+        "sha1": "cbfeed295786c489aa9395886dfd2d19671af22b",
+        "fingerprint": "f32988aa9d6beda19e3c839d0752407e",
+        "original_path": "coalib/results/result_actions/ApplyPatchAction.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/results/result_actions/OpenEditorAction.py",
+        "type": "file",
+        "name": "OpenEditorAction.py",
+        "size": 2125,
+        "sha1": "e0d186c0b4c6fcc6de680748ddae536e0ea08db3",
+        "fingerprint": "8965a1b3265a811555f9e6f686de63a6",
+        "original_path": "coalib/results/result_actions/OpenEditorAction.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/results/result_actions/PrintDebugMessageAction.py",
+        "type": "file",
+        "name": "PrintDebugMessageAction.py",
+        "size": 511,
+        "sha1": "986c5f904a0ee78c85a71d96b6621e85e1a9a8fd",
+        "fingerprint": "356aafc67c4ac74f425c679fe2901cc6",
+        "original_path": "coalib/results/result_actions/PrintDebugMessageAction.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/results/result_actions/PrintMoreInfoAction.py",
+        "type": "file",
+        "name": "PrintMoreInfoAction.py",
+        "size": 530,
+        "sha1": "b81493f315271c5d357ba2b5f1a723cef2a070f4",
+        "fingerprint": "2f7adfe45862d150c35077ebc2b02b76",
+        "original_path": "coalib/results/result_actions/PrintMoreInfoAction.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/results/result_actions/ResultAction.py",
+        "type": "file",
+        "name": "ResultAction.py",
+        "size": 3534,
+        "sha1": "6bf770d692b451f5d0ccfc17b9dd24c82ac43745",
+        "fingerprint": "145051da4cea0672c65bdae10b4e0b63",
+        "original_path": "coalib/results/result_actions/ResultAction.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/results/result_actions/ShowPatchAction.py",
+        "type": "file",
+        "name": "ShowPatchAction.py",
+        "size": 4291,
+        "sha1": "676d5e5de8850d9fbf10cf74af84148c17da9734",
+        "fingerprint": "2b714700258b20a7d93480c64620011e",
+        "original_path": "coalib/results/result_actions/ShowPatchAction.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/settings/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 0,
+        "sha1": null,
+        "fingerprint": null,
+        "original_path": "coalib/settings/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/settings/ConfigurationGathering.py",
+        "type": "file",
+        "name": "ConfigurationGathering.py",
+        "size": 12826,
+        "sha1": "d7ad37ad4817fdeda51adaab56fdb5b30398caaa",
+        "fingerprint": "1b28a404cb47a335877b71cf0ad4e9cd",
+        "original_path": "coalib/settings/ConfigurationGathering.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/settings/DocstringMetadata.py",
+        "type": "file",
+        "name": "DocstringMetadata.py",
+        "size": 2495,
+        "sha1": "027f523e4098610452e54bf6c3f96610f0aec7cf",
+        "fingerprint": "48b8eaa17445cb47e1d89a77cddaf97a",
+        "original_path": "coalib/settings/DocstringMetadata.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/settings/FunctionMetadata.py",
+        "type": "file",
+        "name": "FunctionMetadata.py",
+        "size": 10507,
+        "sha1": "f4da0dce54826c68cb3241e27b09d4478abf23d1",
+        "fingerprint": "7060282c309df21dbf024d9387b674af",
+        "original_path": "coalib/settings/FunctionMetadata.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/settings/Section.py",
+        "type": "file",
+        "name": "Section.py",
+        "size": 8755,
+        "sha1": "c2dd35d5c718ea706bc6869539f9ae568945e8de",
+        "fingerprint": "4778cc063d1df6faaa57173f6ad98770",
+        "original_path": "coalib/settings/Section.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/settings/SectionFilling.py",
+        "type": "file",
+        "name": "SectionFilling.py",
+        "size": 3942,
+        "sha1": "854be00b87187803b6d311592d2842b3ba07be0b",
+        "fingerprint": "931e5295cb2424b587c042a0173295ea",
+        "original_path": "coalib/settings/SectionFilling.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "removed",
+      "factors": [],
+      "score": 0,
+      "new": null,
+      "old": {
+        "path": "coalib/settings/Setting.py",
+        "type": "file",
+        "name": "Setting.py",
+        "size": 8402,
+        "sha1": "a11855347f6d2d12495e265834ef611d254f645c",
+        "fingerprint": "4a1019a9f5b4d802aeca7d2de7d3d0f9",
+        "original_path": "coalib/settings/Setting.py",
         "licenses": [],
         "copyrights": []
       }

--- a/tests/data/deltacode/sugar-expected.json
+++ b/tests/data/deltacode/sugar-expected.json
@@ -17,13 +17,13 @@
       "factors": [],
       "score": 100,
       "new": {
-        "path": "src/jarabe/journal/projectview.py",
+        "path": "src/jarabe/desktop/activitychooser.py",
         "type": "file",
-        "name": "projectview.py",
-        "size": 5486,
-        "sha1": "bea7d8d5de546621bf114984ca63211834858c4f",
-        "fingerprint": "dab4f7bcd0aee5fae626474077b686e4",
-        "original_path": "src/jarabe/journal/projectview.py",
+        "name": "activitychooser.py",
+        "size": 11858,
+        "sha1": "86bb0568a05c34643023dea6a69cb25074d58a8d",
+        "fingerprint": "42f06af2c2d4ca1ab49620c2275ade8c",
+        "original_path": "src/jarabe/desktop/activitychooser.py",
         "licenses": [],
         "copyrights": []
       },
@@ -34,13 +34,13 @@
       "factors": [],
       "score": 100,
       "new": {
-        "path": "src/jarabe/view/viewhelp_webkit2.py",
+        "path": "src/jarabe/journal/projectview.py",
         "type": "file",
-        "name": "viewhelp_webkit2.py",
-        "size": 3617,
-        "sha1": "365a64c1e255e85a74e8fed2d7303fed7c2ea81e",
-        "fingerprint": "7c60cfe2de9bc5ceea2621716fa4a786",
-        "original_path": "src/jarabe/view/viewhelp_webkit2.py",
+        "name": "projectview.py",
+        "size": 5486,
+        "sha1": "bea7d8d5de546621bf114984ca63211834858c4f",
+        "fingerprint": "dab4f7bcd0aee5fae626474077b686e4",
+        "original_path": "src/jarabe/journal/projectview.py",
         "licenses": [],
         "copyrights": []
       },
@@ -68,13 +68,13 @@
       "factors": [],
       "score": 100,
       "new": {
-        "path": "src/jarabe/desktop/activitychooser.py",
+        "path": "src/jarabe/view/viewhelp_webkit2.py",
         "type": "file",
-        "name": "activitychooser.py",
-        "size": 11858,
-        "sha1": "86bb0568a05c34643023dea6a69cb25074d58a8d",
-        "fingerprint": "42f06af2c2d4ca1ab49620c2275ade8c",
-        "original_path": "src/jarabe/desktop/activitychooser.py",
+        "name": "viewhelp_webkit2.py",
+        "size": 3617,
+        "sha1": "365a64c1e255e85a74e8fed2d7303fed7c2ea81e",
+        "fingerprint": "7c60cfe2de9bc5ceea2621716fa4a786",
+        "original_path": "src/jarabe/view/viewhelp_webkit2.py",
         "licenses": [],
         "copyrights": []
       },
@@ -145,35 +145,6 @@
       ],
       "score": 49,
       "new": {
-        "path": "src/jarabe/view/viewhelp.py",
-        "type": "file",
-        "name": "viewhelp.py",
-        "size": 12241,
-        "sha1": "512092ef1ea663f87b58ce7391fba1a8520602fc",
-        "fingerprint": "8ef1cebaa4974c78473c03f007869aa0",
-        "original_path": "src/jarabe/view/viewhelp.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/view/viewhelp.py",
-        "type": "file",
-        "name": "viewhelp.py",
-        "size": 12761,
-        "sha1": "f8575af2f995919f1db32009b34a164046789b13",
-        "fingerprint": "1e6169b804954cfdc6bd0340471698b8",
-        "original_path": "src/jarabe/view/viewhelp.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 29"
-      ],
-      "score": 49,
-      "new": {
         "path": "src/jarabe/controlpanel/sectionview.py",
         "type": "file",
         "name": "sectionview.py",
@@ -192,6 +163,35 @@
         "sha1": "59825c6123bdf90a51683ee7985c0f7824cbc60b",
         "fingerprint": "1eecfdf016b8c76ea3b6410565ae4ea5",
         "original_path": "src/jarabe/controlpanel/sectionview.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 29"
+      ],
+      "score": 49,
+      "new": {
+        "path": "src/jarabe/view/viewhelp.py",
+        "type": "file",
+        "name": "viewhelp.py",
+        "size": 12241,
+        "sha1": "512092ef1ea663f87b58ce7391fba1a8520602fc",
+        "fingerprint": "8ef1cebaa4974c78473c03f007869aa0",
+        "original_path": "src/jarabe/view/viewhelp.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/view/viewhelp.py",
+        "type": "file",
+        "name": "viewhelp.py",
+        "size": 12761,
+        "sha1": "f8575af2f995919f1db32009b34a164046789b13",
+        "fingerprint": "1e6169b804954cfdc6bd0340471698b8",
+        "original_path": "src/jarabe/view/viewhelp.py",
         "licenses": [],
         "copyrights": []
       }
@@ -377,35 +377,6 @@
       ],
       "score": 44,
       "new": {
-        "path": "src/jarabe/webservice/accountsmanager.py",
-        "type": "file",
-        "name": "accountsmanager.py",
-        "size": 7106,
-        "sha1": "c2ec06ae0baf6a4bddec6c72fc7838ef64753c4e",
-        "fingerprint": "b4e577ea824bf3c662640de12d1ff585",
-        "original_path": "src/jarabe/webservice/accountsmanager.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/webservice/accountsmanager.py",
-        "type": "file",
-        "name": "accountsmanager.py",
-        "size": 7190,
-        "sha1": "89105a991611f7b1f250e83ca46c7305e8d262cd",
-        "fingerprint": "94e5f7e01842f1d632760c40af1ff591",
-        "original_path": "src/jarabe/webservice/accountsmanager.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 24"
-      ],
-      "score": 44,
-      "new": {
         "path": "src/jarabe/model/speech.py",
         "type": "file",
         "name": "speech.py",
@@ -431,28 +402,28 @@
     {
       "status": "modified",
       "factors": [
-        "Similar with hamming distance : 23"
+        "Similar with hamming distance : 24"
       ],
-      "score": 43,
+      "score": 44,
       "new": {
-        "path": "src/jarabe/model/desktop.py",
+        "path": "src/jarabe/webservice/accountsmanager.py",
         "type": "file",
-        "name": "desktop.py",
-        "size": 3714,
-        "sha1": "6e5e6de680e23ffc0bb6f4e4f714469cec0d1013",
-        "fingerprint": "d8fc4bb0829be54716a0e1a364aa8cbf",
-        "original_path": "src/jarabe/model/desktop.py",
+        "name": "accountsmanager.py",
+        "size": 7106,
+        "sha1": "c2ec06ae0baf6a4bddec6c72fc7838ef64753c4e",
+        "fingerprint": "b4e577ea824bf3c662640de12d1ff585",
+        "original_path": "src/jarabe/webservice/accountsmanager.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "src/jarabe/model/desktop.py",
+        "path": "src/jarabe/webservice/accountsmanager.py",
         "type": "file",
-        "name": "desktop.py",
-        "size": 3636,
-        "sha1": "2d912a2645d39f165bc11d1cd610b695742e1705",
-        "fingerprint": "5ae44bb2c29fc52606a4412325aacca1",
-        "original_path": "src/jarabe/model/desktop.py",
+        "name": "accountsmanager.py",
+        "size": 7190,
+        "sha1": "89105a991611f7b1f250e83ca46c7305e8d262cd",
+        "fingerprint": "94e5f7e01842f1d632760c40af1ff591",
+        "original_path": "src/jarabe/webservice/accountsmanager.py",
         "licenses": [],
         "copyrights": []
       }
@@ -482,6 +453,35 @@
         "sha1": "41a126b8f58eec7561dede38a17f9d05fed099bd",
         "fingerprint": "7ef04fe2c69fc75ec73ec9256f57ce88",
         "original_path": "src/jarabe/frame/friendstray.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 23"
+      ],
+      "score": 43,
+      "new": {
+        "path": "src/jarabe/model/desktop.py",
+        "type": "file",
+        "name": "desktop.py",
+        "size": 3714,
+        "sha1": "6e5e6de680e23ffc0bb6f4e4f714469cec0d1013",
+        "fingerprint": "d8fc4bb0829be54716a0e1a364aa8cbf",
+        "original_path": "src/jarabe/model/desktop.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/model/desktop.py",
+        "type": "file",
+        "name": "desktop.py",
+        "size": 3636,
+        "sha1": "2d912a2645d39f165bc11d1cd610b695742e1705",
+        "fingerprint": "5ae44bb2c29fc52606a4412325aacca1",
+        "original_path": "src/jarabe/model/desktop.py",
         "licenses": [],
         "copyrights": []
       }
@@ -522,24 +522,24 @@
       ],
       "score": 40,
       "new": {
-        "path": "src/jarabe/util/telepathy/__init__.py",
+        "path": "src/jarabe/desktop/groupbox.py",
         "type": "file",
-        "name": "__init__.py",
-        "size": 731,
-        "sha1": "697c8fe6a59f7c7fe8026bba569135ebe6a1755b",
-        "fingerprint": "b8a46baaf69bc74e2aa661a064aa86a7",
-        "original_path": "src/jarabe/util/telepathy/__init__.py",
+        "name": "groupbox.py",
+        "size": 2812,
+        "sha1": "d90d36b79e75bd89bdcca9a2719ffbecbc79c4b3",
+        "fingerprint": "baf4ffb8668be7462a76a00266e2c6ac",
+        "original_path": "src/jarabe/desktop/groupbox.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "src/jarabe/util/telepathy/__init__.py",
+        "path": "src/jarabe/desktop/groupbox.py",
         "type": "file",
-        "name": "__init__.py",
-        "size": 798,
-        "sha1": "573b1af23e9b4568e16430f2538236eb66df56ca",
-        "fingerprint": "1a244bbad699c76f8ab660a065a69ea5",
-        "original_path": "src/jarabe/util/telepathy/__init__.py",
+        "name": "groupbox.py",
+        "size": 2845,
+        "sha1": "dc2c149a5a4dccacc71a5b59ba38cbe93fa22b5e",
+        "fingerprint": "3ab4dfb82e99ef6f8636a00276e6cea4",
+        "original_path": "src/jarabe/desktop/groupbox.py",
         "licenses": [],
         "copyrights": []
       }
@@ -551,24 +551,53 @@
       ],
       "score": 40,
       "new": {
-        "path": "src/jarabe/view/alerts.py",
+        "path": "src/jarabe/frame/__init__.py",
         "type": "file",
-        "name": "alerts.py",
-        "size": 2055,
-        "sha1": "0b2eaa6e3c6646cf685089827f2857fe55c6710e",
-        "fingerprint": "fa6cecf2c69fc442223423846da2c6a4",
-        "original_path": "src/jarabe/view/alerts.py",
+        "name": "__init__.py",
+        "size": 824,
+        "sha1": "6d7fc42ca9b90ecb1c1f5d573a3c297bccfcd9e6",
+        "fingerprint": "d8e4feead68be7466aa460b264a2a6a7",
+        "original_path": "src/jarabe/frame/__init__.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "src/jarabe/view/alerts.py",
+        "path": "src/jarabe/frame/__init__.py",
         "type": "file",
-        "name": "alerts.py",
-        "size": 2095,
-        "sha1": "3691e6dee61c161094ab130bd034a56ae2286631",
-        "fingerprint": "5a6c6ef2ce1fc46a823e21003fe2d6a4",
-        "original_path": "src/jarabe/view/alerts.py",
+        "name": "__init__.py",
+        "size": 891,
+        "sha1": "1ec9f253c07c3745f7e83694ef1a7b7947169734",
+        "fingerprint": "5ae45fa8d69dc74e02a660a264e2b6a5",
+        "original_path": "src/jarabe/frame/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 20"
+      ],
+      "score": 40,
+      "new": {
+        "path": "src/jarabe/intro/genderpicker.py",
+        "type": "file",
+        "name": "genderpicker.py",
+        "size": 3248,
+        "sha1": "36f2abb02cfe7c81e38f890a72fa1b0a9769c777",
+        "fingerprint": "12f9ea2a8ecf4d566626a13277cae5a2",
+        "original_path": "src/jarabe/intro/genderpicker.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/intro/genderpicker.py",
+        "type": "file",
+        "name": "genderpicker.py",
+        "size": 3502,
+        "sha1": "e4c74c8730fe324b3d60c35a350866e4a74f9521",
+        "fingerprint": "52796b8a8e5dcf7e66a6a12277fef4a2",
+        "original_path": "src/jarabe/intro/genderpicker.py",
         "licenses": [],
         "copyrights": []
       }
@@ -638,24 +667,24 @@
       ],
       "score": 40,
       "new": {
-        "path": "src/jarabe/desktop/groupbox.py",
+        "path": "src/jarabe/util/telepathy/__init__.py",
         "type": "file",
-        "name": "groupbox.py",
-        "size": 2812,
-        "sha1": "d90d36b79e75bd89bdcca9a2719ffbecbc79c4b3",
-        "fingerprint": "baf4ffb8668be7462a76a00266e2c6ac",
-        "original_path": "src/jarabe/desktop/groupbox.py",
+        "name": "__init__.py",
+        "size": 731,
+        "sha1": "697c8fe6a59f7c7fe8026bba569135ebe6a1755b",
+        "fingerprint": "b8a46baaf69bc74e2aa661a064aa86a7",
+        "original_path": "src/jarabe/util/telepathy/__init__.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "src/jarabe/desktop/groupbox.py",
+        "path": "src/jarabe/util/telepathy/__init__.py",
         "type": "file",
-        "name": "groupbox.py",
-        "size": 2845,
-        "sha1": "dc2c149a5a4dccacc71a5b59ba38cbe93fa22b5e",
-        "fingerprint": "3ab4dfb82e99ef6f8636a00276e6cea4",
-        "original_path": "src/jarabe/desktop/groupbox.py",
+        "name": "__init__.py",
+        "size": 798,
+        "sha1": "573b1af23e9b4568e16430f2538236eb66df56ca",
+        "fingerprint": "1a244bbad699c76f8ab660a065a69ea5",
+        "original_path": "src/jarabe/util/telepathy/__init__.py",
         "licenses": [],
         "copyrights": []
       }
@@ -667,198 +696,24 @@
       ],
       "score": 40,
       "new": {
-        "path": "src/jarabe/intro/genderpicker.py",
+        "path": "src/jarabe/view/alerts.py",
         "type": "file",
-        "name": "genderpicker.py",
-        "size": 3248,
-        "sha1": "36f2abb02cfe7c81e38f890a72fa1b0a9769c777",
-        "fingerprint": "12f9ea2a8ecf4d566626a13277cae5a2",
-        "original_path": "src/jarabe/intro/genderpicker.py",
+        "name": "alerts.py",
+        "size": 2055,
+        "sha1": "0b2eaa6e3c6646cf685089827f2857fe55c6710e",
+        "fingerprint": "fa6cecf2c69fc442223423846da2c6a4",
+        "original_path": "src/jarabe/view/alerts.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "src/jarabe/intro/genderpicker.py",
+        "path": "src/jarabe/view/alerts.py",
         "type": "file",
-        "name": "genderpicker.py",
-        "size": 3502,
-        "sha1": "e4c74c8730fe324b3d60c35a350866e4a74f9521",
-        "fingerprint": "52796b8a8e5dcf7e66a6a12277fef4a2",
-        "original_path": "src/jarabe/intro/genderpicker.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 20"
-      ],
-      "score": 40,
-      "new": {
-        "path": "src/jarabe/frame/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 824,
-        "sha1": "6d7fc42ca9b90ecb1c1f5d573a3c297bccfcd9e6",
-        "fingerprint": "d8e4feead68be7466aa460b264a2a6a7",
-        "original_path": "src/jarabe/frame/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/frame/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 891,
-        "sha1": "1ec9f253c07c3745f7e83694ef1a7b7947169734",
-        "fingerprint": "5ae45fa8d69dc74e02a660a264e2b6a5",
-        "original_path": "src/jarabe/frame/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 19"
-      ],
-      "score": 39,
-      "new": {
-        "path": "src/jarabe/journal/journalactivity.py",
-        "type": "file",
-        "name": "journalactivity.py",
-        "size": 23977,
-        "sha1": "2284fd2226629da274c505cc20273d35ecc30e4c",
-        "fingerprint": "cc69fa14a733fe8f5677273a27ba9177",
-        "original_path": "src/jarabe/journal/journalactivity.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/journal/journalactivity.py",
-        "type": "file",
-        "name": "journalactivity.py",
-        "size": 17450,
-        "sha1": "2428c1761ca0aaadde17872120bccc2f5c01b6c9",
-        "fingerprint": "cce9fab8b733eecf546e873a67ba95d5",
-        "original_path": "src/jarabe/journal/journalactivity.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 19"
-      ],
-      "score": 39,
-      "new": {
-        "path": "src/jarabe/model/keyboard.py",
-        "type": "file",
-        "name": "keyboard.py",
-        "size": 2222,
-        "sha1": "de63e99ccdc829360439d9d6becb897affa63926",
-        "fingerprint": "72f12e68429bc70e0ab263a264e296e5",
-        "original_path": "src/jarabe/model/keyboard.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/model/keyboard.py",
-        "type": "file",
-        "name": "keyboard.py",
-        "size": 2246,
-        "sha1": "718eea4dcd11e6db924e8fadbfbdd60847ae48b3",
-        "fingerprint": "52f16fa84399cf8e0eb240a327e29ea5",
-        "original_path": "src/jarabe/model/keyboard.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 19"
-      ],
-      "score": 39,
-      "new": {
-        "path": "src/jarabe/desktop/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 677,
-        "sha1": "88162a20ff790a3197b028a0b4944e2132af17a0",
-        "fingerprint": "d8e4ebaad68be74e6a2661b164a2a6a7",
-        "original_path": "src/jarabe/desktop/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/desktop/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 744,
-        "sha1": "a9edbe327bea935ca59ebbc43f38d0fd906573c8",
-        "fingerprint": "5ae443a8d699c74e22a661a065a29ea5",
-        "original_path": "src/jarabe/desktop/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 19"
-      ],
-      "score": 39,
-      "new": {
-        "path": "src/jarabe/model/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 677,
-        "sha1": "88162a20ff790a3197b028a0b4944e2132af17a0",
-        "fingerprint": "d8e4ebaad68be74e6a2661b164a2a6a7",
-        "original_path": "src/jarabe/model/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/model/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 744,
-        "sha1": "a9edbe327bea935ca59ebbc43f38d0fd906573c8",
-        "fingerprint": "5ae443a8d699c74e22a661a065a29ea5",
-        "original_path": "src/jarabe/model/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 19"
-      ],
-      "score": 39,
-      "new": {
-        "path": "src/jarabe/view/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 677,
-        "sha1": "88162a20ff790a3197b028a0b4944e2132af17a0",
-        "fingerprint": "d8e4ebaad68be74e6a2661b164a2a6a7",
-        "original_path": "src/jarabe/view/__init__.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/view/__init__.py",
-        "type": "file",
-        "name": "__init__.py",
-        "size": 744,
-        "sha1": "a9edbe327bea935ca59ebbc43f38d0fd906573c8",
-        "fingerprint": "5ae443a8d699c74e22a661a065a29ea5",
-        "original_path": "src/jarabe/view/__init__.py",
+        "name": "alerts.py",
+        "size": 2095,
+        "sha1": "3691e6dee61c161094ab130bd034a56ae2286631",
+        "fingerprint": "5a6c6ef2ce1fc46a823e21003fe2d6a4",
+        "original_path": "src/jarabe/view/alerts.py",
         "licenses": [],
         "copyrights": []
       }
@@ -899,6 +754,64 @@
       ],
       "score": 39,
       "new": {
+        "path": "src/jarabe/controlpanel/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 677,
+        "sha1": "88162a20ff790a3197b028a0b4944e2132af17a0",
+        "fingerprint": "d8e4ebaad68be74e6a2661b164a2a6a7",
+        "original_path": "src/jarabe/controlpanel/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/controlpanel/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 744,
+        "sha1": "a9edbe327bea935ca59ebbc43f38d0fd906573c8",
+        "fingerprint": "5ae443a8d699c74e22a661a065a29ea5",
+        "original_path": "src/jarabe/controlpanel/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 19"
+      ],
+      "score": 39,
+      "new": {
+        "path": "src/jarabe/desktop/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 677,
+        "sha1": "88162a20ff790a3197b028a0b4944e2132af17a0",
+        "fingerprint": "d8e4ebaad68be74e6a2661b164a2a6a7",
+        "original_path": "src/jarabe/desktop/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/desktop/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 744,
+        "sha1": "a9edbe327bea935ca59ebbc43f38d0fd906573c8",
+        "fingerprint": "5ae443a8d699c74e22a661a065a29ea5",
+        "original_path": "src/jarabe/desktop/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 19"
+      ],
+      "score": 39,
+      "new": {
         "path": "src/jarabe/desktop/viewcontainer.py",
         "type": "file",
         "name": "viewcontainer.py",
@@ -928,24 +841,111 @@
       ],
       "score": 39,
       "new": {
-        "path": "src/jarabe/controlpanel/__init__.py",
+        "path": "src/jarabe/journal/journalactivity.py",
+        "type": "file",
+        "name": "journalactivity.py",
+        "size": 23977,
+        "sha1": "2284fd2226629da274c505cc20273d35ecc30e4c",
+        "fingerprint": "cc69fa14a733fe8f5677273a27ba9177",
+        "original_path": "src/jarabe/journal/journalactivity.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/journal/journalactivity.py",
+        "type": "file",
+        "name": "journalactivity.py",
+        "size": 17450,
+        "sha1": "2428c1761ca0aaadde17872120bccc2f5c01b6c9",
+        "fingerprint": "cce9fab8b733eecf546e873a67ba95d5",
+        "original_path": "src/jarabe/journal/journalactivity.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 19"
+      ],
+      "score": 39,
+      "new": {
+        "path": "src/jarabe/model/__init__.py",
         "type": "file",
         "name": "__init__.py",
         "size": 677,
         "sha1": "88162a20ff790a3197b028a0b4944e2132af17a0",
         "fingerprint": "d8e4ebaad68be74e6a2661b164a2a6a7",
-        "original_path": "src/jarabe/controlpanel/__init__.py",
+        "original_path": "src/jarabe/model/__init__.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "src/jarabe/controlpanel/__init__.py",
+        "path": "src/jarabe/model/__init__.py",
         "type": "file",
         "name": "__init__.py",
         "size": 744,
         "sha1": "a9edbe327bea935ca59ebbc43f38d0fd906573c8",
         "fingerprint": "5ae443a8d699c74e22a661a065a29ea5",
-        "original_path": "src/jarabe/controlpanel/__init__.py",
+        "original_path": "src/jarabe/model/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 19"
+      ],
+      "score": 39,
+      "new": {
+        "path": "src/jarabe/model/keyboard.py",
+        "type": "file",
+        "name": "keyboard.py",
+        "size": 2222,
+        "sha1": "de63e99ccdc829360439d9d6becb897affa63926",
+        "fingerprint": "72f12e68429bc70e0ab263a264e296e5",
+        "original_path": "src/jarabe/model/keyboard.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/model/keyboard.py",
+        "type": "file",
+        "name": "keyboard.py",
+        "size": 2246,
+        "sha1": "718eea4dcd11e6db924e8fadbfbdd60847ae48b3",
+        "fingerprint": "52f16fa84399cf8e0eb240a327e29ea5",
+        "original_path": "src/jarabe/model/keyboard.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 19"
+      ],
+      "score": 39,
+      "new": {
+        "path": "src/jarabe/view/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 677,
+        "sha1": "88162a20ff790a3197b028a0b4944e2132af17a0",
+        "fingerprint": "d8e4ebaad68be74e6a2661b164a2a6a7",
+        "original_path": "src/jarabe/view/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/view/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 744,
+        "sha1": "a9edbe327bea935ca59ebbc43f38d0fd906573c8",
+        "fingerprint": "5ae443a8d699c74e22a661a065a29ea5",
+        "original_path": "src/jarabe/view/__init__.py",
         "licenses": [],
         "copyrights": []
       }
@@ -957,24 +957,24 @@
       ],
       "score": 38,
       "new": {
-        "path": "src/jarabe/view/buddymenu.py",
+        "path": "src/jarabe/config.py.in",
         "type": "file",
-        "name": "buddymenu.py",
-        "size": 8681,
-        "sha1": "0c3d6b444da40574cd7f225f491221efaaaf1bbd",
-        "fingerprint": "8bed778ac79905421bb4e19464a7af2e",
-        "original_path": "src/jarabe/view/buddymenu.py",
+        "name": "config.py.in",
+        "size": 889,
+        "sha1": "d9b8cd3bfeaabb6d6cf5c020a600002ea87b85ee",
+        "fingerprint": "d8e4fbead69bef462aa461b065a2e7a3",
+        "original_path": "src/jarabe/config.py.in",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "src/jarabe/view/buddymenu.py",
+        "path": "src/jarabe/config.py.in",
         "type": "file",
-        "name": "buddymenu.py",
-        "size": 8556,
-        "sha1": "a8ef370e353bfcc437a810f427c0eb3bd3b7514a",
-        "fingerprint": "8bed5f88c298210203b4608464a7be28",
-        "original_path": "src/jarabe/view/buddymenu.py",
+        "name": "config.py.in",
+        "size": 956,
+        "sha1": "b6cc9987b163a5844fb726f623effc34c7561522",
+        "fingerprint": "18e4e3bad69bcf4e22a661a065e6dea1",
+        "original_path": "src/jarabe/config.py.in",
         "licenses": [],
         "copyrights": []
       }
@@ -1015,24 +1015,53 @@
       ],
       "score": 38,
       "new": {
-        "path": "src/jarabe/view/buddyicon.py",
+        "path": "src/jarabe/model/notifications.py",
         "type": "file",
-        "name": "buddyicon.py",
-        "size": 2754,
-        "sha1": "1b2f5913b20b3969285e0541f65e276e5d262db5",
-        "fingerprint": "baf4f3a2168be5c62a3760f166a2c6a8",
-        "original_path": "src/jarabe/view/buddyicon.py",
+        "name": "notifications.py",
+        "size": 4491,
+        "sha1": "8ec982bd679849d365d9332578771d68fd73ece2",
+        "fingerprint": "b974e028e689846232a621e36caaa6af",
+        "original_path": "src/jarabe/model/notifications.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "src/jarabe/view/buddyicon.py",
+        "path": "src/jarabe/model/notifications.py",
         "type": "file",
-        "name": "buddyicon.py",
-        "size": 2820,
-        "sha1": "72d94534a6b30718969f7a8b026dc3de20def7e5",
-        "fingerprint": "3ee453a2968dc5c72eb760e17ea6d6a0",
-        "original_path": "src/jarabe/view/buddyicon.py",
+        "name": "notifications.py",
+        "size": 4556,
+        "sha1": "1caecba929d1c6c8783044be1c62a109dc7d01bd",
+        "fingerprint": "bd2460a8c6c9806b82a601e35caaa6a9",
+        "original_path": "src/jarabe/model/notifications.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 18"
+      ],
+      "score": 38,
+      "new": {
+        "path": "src/jarabe/model/telepathyclient.py",
+        "type": "file",
+        "name": "telepathyclient.py",
+        "size": 5202,
+        "sha1": "0b0d1500ca8a16f4a2d5edb9794568c9fd1b9953",
+        "fingerprint": "7e24fbac6289e746202ee72c6482f3c4",
+        "original_path": "src/jarabe/model/telepathyclient.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/model/telepathyclient.py",
+        "type": "file",
+        "name": "telepathyclient.py",
+        "size": 5266,
+        "sha1": "46d7d62f4b7f87a84cf6475f10ae5f71adaad75a",
+        "fingerprint": "7e64fba443d5e747203ee7243402fa80",
+        "original_path": "src/jarabe/model/telepathyclient.py",
         "licenses": [],
         "copyrights": []
       }
@@ -1102,24 +1131,24 @@
       ],
       "score": 38,
       "new": {
-        "path": "src/jarabe/model/telepathyclient.py",
+        "path": "src/jarabe/view/buddyicon.py",
         "type": "file",
-        "name": "telepathyclient.py",
-        "size": 5202,
-        "sha1": "0b0d1500ca8a16f4a2d5edb9794568c9fd1b9953",
-        "fingerprint": "7e24fbac6289e746202ee72c6482f3c4",
-        "original_path": "src/jarabe/model/telepathyclient.py",
+        "name": "buddyicon.py",
+        "size": 2754,
+        "sha1": "1b2f5913b20b3969285e0541f65e276e5d262db5",
+        "fingerprint": "baf4f3a2168be5c62a3760f166a2c6a8",
+        "original_path": "src/jarabe/view/buddyicon.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "src/jarabe/model/telepathyclient.py",
+        "path": "src/jarabe/view/buddyicon.py",
         "type": "file",
-        "name": "telepathyclient.py",
-        "size": 5266,
-        "sha1": "46d7d62f4b7f87a84cf6475f10ae5f71adaad75a",
-        "fingerprint": "7e64fba443d5e747203ee7243402fa80",
-        "original_path": "src/jarabe/model/telepathyclient.py",
+        "name": "buddyicon.py",
+        "size": 2820,
+        "sha1": "72d94534a6b30718969f7a8b026dc3de20def7e5",
+        "fingerprint": "3ee453a2968dc5c72eb760e17ea6d6a0",
+        "original_path": "src/jarabe/view/buddyicon.py",
         "licenses": [],
         "copyrights": []
       }
@@ -1131,82 +1160,24 @@
       ],
       "score": 38,
       "new": {
-        "path": "src/jarabe/model/notifications.py",
+        "path": "src/jarabe/view/buddymenu.py",
         "type": "file",
-        "name": "notifications.py",
-        "size": 4491,
-        "sha1": "8ec982bd679849d365d9332578771d68fd73ece2",
-        "fingerprint": "b974e028e689846232a621e36caaa6af",
-        "original_path": "src/jarabe/model/notifications.py",
+        "name": "buddymenu.py",
+        "size": 8681,
+        "sha1": "0c3d6b444da40574cd7f225f491221efaaaf1bbd",
+        "fingerprint": "8bed778ac79905421bb4e19464a7af2e",
+        "original_path": "src/jarabe/view/buddymenu.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "src/jarabe/model/notifications.py",
+        "path": "src/jarabe/view/buddymenu.py",
         "type": "file",
-        "name": "notifications.py",
-        "size": 4556,
-        "sha1": "1caecba929d1c6c8783044be1c62a109dc7d01bd",
-        "fingerprint": "bd2460a8c6c9806b82a601e35caaa6a9",
-        "original_path": "src/jarabe/model/notifications.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 18"
-      ],
-      "score": 38,
-      "new": {
-        "path": "src/jarabe/config.py.in",
-        "type": "file",
-        "name": "config.py.in",
-        "size": 889,
-        "sha1": "d9b8cd3bfeaabb6d6cf5c020a600002ea87b85ee",
-        "fingerprint": "d8e4fbead69bef462aa461b065a2e7a3",
-        "original_path": "src/jarabe/config.py.in",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/config.py.in",
-        "type": "file",
-        "name": "config.py.in",
-        "size": 956,
-        "sha1": "b6cc9987b163a5844fb726f623effc34c7561522",
-        "fingerprint": "18e4e3bad69bcf4e22a661a065e6dea1",
-        "original_path": "src/jarabe/config.py.in",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 17"
-      ],
-      "score": 37,
-      "new": {
-        "path": "src/jarabe/journal/keepicon.py",
-        "type": "file",
-        "name": "keepicon.py",
-        "size": 2441,
-        "sha1": "09e75da17325bac9c1572a7c189083c802826301",
-        "fingerprint": "f8edc3e8a68ccf672296253164abcde7",
-        "original_path": "src/jarabe/journal/keepicon.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/journal/keepicon.py",
-        "type": "file",
-        "name": "keepicon.py",
-        "size": 2430,
-        "sha1": "636847b951f2a433049bc03d2cde113d306358c8",
-        "fingerprint": "5865c3e8969ccf6f00b6252165efcce5",
-        "original_path": "src/jarabe/journal/keepicon.py",
+        "name": "buddymenu.py",
+        "size": 8556,
+        "sha1": "a8ef370e353bfcc437a810f427c0eb3bd3b7514a",
+        "fingerprint": "8bed5f88c298210203b4608464a7be28",
+        "original_path": "src/jarabe/view/buddymenu.py",
         "licenses": [],
         "copyrights": []
       }
@@ -1247,6 +1218,35 @@
       ],
       "score": 37,
       "new": {
+        "path": "src/jarabe/desktop/friendview.py",
+        "type": "file",
+        "name": "friendview.py",
+        "size": 3275,
+        "sha1": "a878a31b24930bdc72240325648b137e4ceec822",
+        "fingerprint": "bcf8d1a6de89d6c34226e8b074e0b726",
+        "original_path": "src/jarabe/desktop/friendview.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/desktop/friendview.py",
+        "type": "file",
+        "name": "friendview.py",
+        "size": 3341,
+        "sha1": "82cfc49140962b54ecab2c7babe7d05c55565a6b",
+        "fingerprint": "96e051a6de99c6cb02a6e8a034e4b620",
+        "original_path": "src/jarabe/desktop/friendview.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 17"
+      ],
+      "score": 37,
+      "new": {
         "path": "src/jarabe/desktop/transitionbox.py",
         "type": "file",
         "name": "transitionbox.py",
@@ -1265,6 +1265,35 @@
         "sha1": "cf6e5e75379d8f0d512d19fd6453aed0d9074816",
         "fingerprint": "5abc7bb88e99c746a2a4260377b296a4",
         "original_path": "src/jarabe/desktop/transitionbox.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 17"
+      ],
+      "score": 37,
+      "new": {
+        "path": "src/jarabe/intro/colorpicker.py",
+        "type": "file",
+        "name": "colorpicker.py",
+        "size": 1572,
+        "sha1": "d8de5269c37d563beed5be95360cf1b19e82037a",
+        "fingerprint": "f8f5f3bae69bcd462aa6a57165a28eac",
+        "original_path": "src/jarabe/intro/colorpicker.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/intro/colorpicker.py",
+        "type": "file",
+        "name": "colorpicker.py",
+        "size": 1638,
+        "sha1": "1ff247108c024ccaf08c086cdf85cecfefb9157b",
+        "fingerprint": "52f573b8c699cd66a2a6a46165269ea4",
+        "original_path": "src/jarabe/intro/colorpicker.py",
         "licenses": [],
         "copyrights": []
       }
@@ -1305,6 +1334,35 @@
       ],
       "score": 37,
       "new": {
+        "path": "src/jarabe/journal/keepicon.py",
+        "type": "file",
+        "name": "keepicon.py",
+        "size": 2441,
+        "sha1": "09e75da17325bac9c1572a7c189083c802826301",
+        "fingerprint": "f8edc3e8a68ccf672296253164abcde7",
+        "original_path": "src/jarabe/journal/keepicon.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/journal/keepicon.py",
+        "type": "file",
+        "name": "keepicon.py",
+        "size": 2430,
+        "sha1": "636847b951f2a433049bc03d2cde113d306358c8",
+        "fingerprint": "5865c3e8969ccf6f00b6252165efcce5",
+        "original_path": "src/jarabe/journal/keepicon.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 17"
+      ],
+      "score": 37,
+      "new": {
         "path": "src/jarabe/model/bundleregistry.py",
         "type": "file",
         "name": "bundleregistry.py",
@@ -1330,57 +1388,28 @@
     {
       "status": "modified",
       "factors": [
-        "Similar with hamming distance : 17"
+        "Similar with hamming distance : 16"
       ],
-      "score": 37,
+      "score": 36,
       "new": {
-        "path": "src/jarabe/desktop/friendview.py",
+        "path": "src/jarabe/controlpanel/gui.py",
         "type": "file",
-        "name": "friendview.py",
-        "size": 3275,
-        "sha1": "a878a31b24930bdc72240325648b137e4ceec822",
-        "fingerprint": "bcf8d1a6de89d6c34226e8b074e0b726",
-        "original_path": "src/jarabe/desktop/friendview.py",
+        "name": "gui.py",
+        "size": 21442,
+        "sha1": "2ea8bdac215993ff0c146aa4f3640e0dfeefc1f6",
+        "fingerprint": "81206db29edf01b08abeea606d8fb6c2",
+        "original_path": "src/jarabe/controlpanel/gui.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "src/jarabe/desktop/friendview.py",
+        "path": "src/jarabe/controlpanel/gui.py",
         "type": "file",
-        "name": "friendview.py",
-        "size": 3341,
-        "sha1": "82cfc49140962b54ecab2c7babe7d05c55565a6b",
-        "fingerprint": "96e051a6de99c6cb02a6e8a034e4b620",
-        "original_path": "src/jarabe/desktop/friendview.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 17"
-      ],
-      "score": 37,
-      "new": {
-        "path": "src/jarabe/intro/colorpicker.py",
-        "type": "file",
-        "name": "colorpicker.py",
-        "size": 1572,
-        "sha1": "d8de5269c37d563beed5be95360cf1b19e82037a",
-        "fingerprint": "f8f5f3bae69bcd462aa6a57165a28eac",
-        "original_path": "src/jarabe/intro/colorpicker.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/intro/colorpicker.py",
-        "type": "file",
-        "name": "colorpicker.py",
-        "size": 1638,
-        "sha1": "1ff247108c024ccaf08c086cdf85cecfefb9157b",
-        "fingerprint": "52f573b8c699cd66a2a6a46165269ea4",
-        "original_path": "src/jarabe/intro/colorpicker.py",
+        "name": "gui.py",
+        "size": 20449,
+        "sha1": "52175d6701b646b0b142fc60f6bf4228147fc781",
+        "fingerprint": "042069b29edf03b0cebeea206ea6f692",
+        "original_path": "src/jarabe/controlpanel/gui.py",
         "licenses": [],
         "copyrights": []
       }
@@ -1392,169 +1421,24 @@
       ],
       "score": 36,
       "new": {
-        "path": "src/jarabe/intro/window.py",
+        "path": "src/jarabe/desktop/activitieslist.py",
         "type": "file",
-        "name": "window.py",
-        "size": 13552,
-        "sha1": "44197f8f07a654dcb4aaa12f9279ce50c99dbc7e",
-        "fingerprint": "5bf5cea88cabf3f26e4ec1e8e4d3ae24",
-        "original_path": "src/jarabe/intro/window.py",
+        "name": "activitieslist.py",
+        "size": 28491,
+        "sha1": "73c0c09da8495d7d08a37462c35cac21f9f2cee7",
+        "fingerprint": "91a06fba1b500bb8e3a7e7a10431b132",
+        "original_path": "src/jarabe/desktop/activitieslist.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "src/jarabe/intro/window.py",
+        "path": "src/jarabe/desktop/activitieslist.py",
         "type": "file",
-        "name": "window.py",
-        "size": 13458,
-        "sha1": "238e5145080c2bc4810032affb72358ff1001d45",
-        "fingerprint": "52f4ce8a8ea9ebe66e4e41e8a483be24",
-        "original_path": "src/jarabe/intro/window.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 16"
-      ],
-      "score": 36,
-      "new": {
-        "path": "src/jarabe/journal/iconmodel.py",
-        "type": "file",
-        "name": "iconmodel.py",
-        "size": 4390,
-        "sha1": "bad5e8adb2e987dc63e1e8240ab43d037d16e1fd",
-        "fingerprint": "b9e17d60c29bcd5e1eb443b56de68ea6",
-        "original_path": "src/jarabe/journal/iconmodel.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/journal/iconmodel.py",
-        "type": "file",
-        "name": "iconmodel.py",
-        "size": 4444,
-        "sha1": "de501b6842eb6002b3f5b76a84f62374e804a9f0",
-        "fingerprint": "18e455e0cafbc97e1eb443a46df68ea6",
-        "original_path": "src/jarabe/journal/iconmodel.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 16"
-      ],
-      "score": 36,
-      "new": {
-        "path": "src/jarabe/journal/listview.py",
-        "type": "file",
-        "name": "listview.py",
-        "size": 34423,
-        "sha1": "75b45749051d348c33d45fb46874dc707e8389a7",
-        "fingerprint": "dec4d4da9d7aff6004e32ef632efc5b0",
-        "original_path": "src/jarabe/journal/listview.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/journal/listview.py",
-        "type": "file",
-        "name": "listview.py",
-        "size": 31703,
-        "sha1": "3d8baf7b4a7c69c0e87129821fc9268c52bfb10f",
-        "fingerprint": "de44f0de9d7aef6886e327f736f7c5e0",
-        "original_path": "src/jarabe/journal/listview.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 16"
-      ],
-      "score": 36,
-      "new": {
-        "path": "src/jarabe/model/brightness.py",
-        "type": "file",
-        "name": "brightness.py",
-        "size": 4879,
-        "sha1": "184b2822b3f35a423688307009791037e4865c6d",
-        "fingerprint": "cce4cfe48711e76f2a36228261aa8689",
-        "original_path": "src/jarabe/model/brightness.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/model/brightness.py",
-        "type": "file",
-        "name": "brightness.py",
-        "size": 4846,
-        "sha1": "edbadcc62d6e1530b2ca0529918dd6de6ff76a36",
-        "fingerprint": "cce4efe48330c76f8636a28275a69681",
-        "original_path": "src/jarabe/model/brightness.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 16"
-      ],
-      "score": 36,
-      "new": {
-        "path": "src/jarabe/frame/framewindow.py",
-        "type": "file",
-        "name": "framewindow.py",
-        "size": 5682,
-        "sha1": "8a2e6df614352baf241093e664ad8c77868a3428",
-        "fingerprint": "51b5eb6395897cb26aacb58024c59ef5",
-        "original_path": "src/jarabe/frame/framewindow.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/frame/framewindow.py",
-        "type": "file",
-        "name": "framewindow.py",
-        "size": 5668,
-        "sha1": "94a4f31bb2398a81df7c76074641c332a4bdb03e",
-        "fingerprint": "54b5eb7399a96cbeaabc958035459ef5",
-        "original_path": "src/jarabe/frame/framewindow.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 16"
-      ],
-      "score": 36,
-      "new": {
-        "path": "src/jarabe/view/cursortracker.py",
-        "type": "file",
-        "name": "cursortracker.py",
-        "size": 1728,
-        "sha1": "c7d296d7ea47181cb8d1a86ba6aa45e435d24e31",
-        "fingerprint": "5aaceeeac68b8d4a2a1461e266b38b60",
-        "original_path": "src/jarabe/view/cursortracker.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/view/cursortracker.py",
-        "type": "file",
-        "name": "cursortracker.py",
-        "size": 1795,
-        "sha1": "b0fc71ba8210a7ac35013c91ae6bffd212be412f",
-        "fingerprint": "5aa46ee886898d4b223461e277368e20",
-        "original_path": "src/jarabe/view/cursortracker.py",
+        "name": "activitieslist.py",
+        "size": 25528,
+        "sha1": "da1fe7b2b215bc9c086244b3224cb6b5ae356606",
+        "fingerprint": "93816fba1b700bf9c18786a144309172",
+        "original_path": "src/jarabe/desktop/activitieslist.py",
         "licenses": [],
         "copyrights": []
       }
@@ -1624,35 +1508,6 @@
       ],
       "score": 36,
       "new": {
-        "path": "src/jarabe/view/launcher.py",
-        "type": "file",
-        "name": "launcher.py",
-        "size": 6044,
-        "sha1": "9b7f24c52515bd673bc2fe86be47460107e26c9f",
-        "fingerprint": "baf5d3ea1a8a7e9e23a5e3a067b2aa18",
-        "original_path": "src/jarabe/view/launcher.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/view/launcher.py",
-        "type": "file",
-        "name": "launcher.py",
-        "size": 6111,
-        "sha1": "43135df11d30021b91878c7b9a6a91aae610f407",
-        "fingerprint": "baf4c3a89a9a6a9ea7a4e38067328a90",
-        "original_path": "src/jarabe/view/launcher.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 16"
-      ],
-      "score": 36,
-      "new": {
         "path": "src/jarabe/frame/frameinvoker.py",
         "type": "file",
         "name": "frameinvoker.py",
@@ -1671,6 +1526,93 @@
         "sha1": "2aaafb97bad60d7a938c15c9ef9289916644817d",
         "fingerprint": "1ee453b0c6bbc7eea6aee5e035e69ea4",
         "original_path": "src/jarabe/frame/frameinvoker.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 16"
+      ],
+      "score": 36,
+      "new": {
+        "path": "src/jarabe/frame/framewindow.py",
+        "type": "file",
+        "name": "framewindow.py",
+        "size": 5682,
+        "sha1": "8a2e6df614352baf241093e664ad8c77868a3428",
+        "fingerprint": "51b5eb6395897cb26aacb58024c59ef5",
+        "original_path": "src/jarabe/frame/framewindow.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/frame/framewindow.py",
+        "type": "file",
+        "name": "framewindow.py",
+        "size": 5668,
+        "sha1": "94a4f31bb2398a81df7c76074641c332a4bdb03e",
+        "fingerprint": "54b5eb7399a96cbeaabc958035459ef5",
+        "original_path": "src/jarabe/frame/framewindow.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 16"
+      ],
+      "score": 36,
+      "new": {
+        "path": "src/jarabe/intro/window.py",
+        "type": "file",
+        "name": "window.py",
+        "size": 13552,
+        "sha1": "44197f8f07a654dcb4aaa12f9279ce50c99dbc7e",
+        "fingerprint": "5bf5cea88cabf3f26e4ec1e8e4d3ae24",
+        "original_path": "src/jarabe/intro/window.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/intro/window.py",
+        "type": "file",
+        "name": "window.py",
+        "size": 13458,
+        "sha1": "238e5145080c2bc4810032affb72358ff1001d45",
+        "fingerprint": "52f4ce8a8ea9ebe66e4e41e8a483be24",
+        "original_path": "src/jarabe/intro/window.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 16"
+      ],
+      "score": 36,
+      "new": {
+        "path": "src/jarabe/journal/iconmodel.py",
+        "type": "file",
+        "name": "iconmodel.py",
+        "size": 4390,
+        "sha1": "bad5e8adb2e987dc63e1e8240ab43d037d16e1fd",
+        "fingerprint": "b9e17d60c29bcd5e1eb443b56de68ea6",
+        "original_path": "src/jarabe/journal/iconmodel.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/journal/iconmodel.py",
+        "type": "file",
+        "name": "iconmodel.py",
+        "size": 4444,
+        "sha1": "de501b6842eb6002b3f5b76a84f62374e804a9f0",
+        "fingerprint": "18e455e0cafbc97e1eb443a46df68ea6",
+        "original_path": "src/jarabe/journal/iconmodel.py",
         "licenses": [],
         "copyrights": []
       }
@@ -1711,24 +1653,53 @@
       ],
       "score": 36,
       "new": {
-        "path": "src/jarabe/controlpanel/gui.py",
+        "path": "src/jarabe/journal/listview.py",
         "type": "file",
-        "name": "gui.py",
-        "size": 21442,
-        "sha1": "2ea8bdac215993ff0c146aa4f3640e0dfeefc1f6",
-        "fingerprint": "81206db29edf01b08abeea606d8fb6c2",
-        "original_path": "src/jarabe/controlpanel/gui.py",
+        "name": "listview.py",
+        "size": 34423,
+        "sha1": "75b45749051d348c33d45fb46874dc707e8389a7",
+        "fingerprint": "dec4d4da9d7aff6004e32ef632efc5b0",
+        "original_path": "src/jarabe/journal/listview.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "src/jarabe/controlpanel/gui.py",
+        "path": "src/jarabe/journal/listview.py",
         "type": "file",
-        "name": "gui.py",
-        "size": 20449,
-        "sha1": "52175d6701b646b0b142fc60f6bf4228147fc781",
-        "fingerprint": "042069b29edf03b0cebeea206ea6f692",
-        "original_path": "src/jarabe/controlpanel/gui.py",
+        "name": "listview.py",
+        "size": 31703,
+        "sha1": "3d8baf7b4a7c69c0e87129821fc9268c52bfb10f",
+        "fingerprint": "de44f0de9d7aef6886e327f736f7c5e0",
+        "original_path": "src/jarabe/journal/listview.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 16"
+      ],
+      "score": 36,
+      "new": {
+        "path": "src/jarabe/model/brightness.py",
+        "type": "file",
+        "name": "brightness.py",
+        "size": 4879,
+        "sha1": "184b2822b3f35a423688307009791037e4865c6d",
+        "fingerprint": "cce4cfe48711e76f2a36228261aa8689",
+        "original_path": "src/jarabe/model/brightness.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/model/brightness.py",
+        "type": "file",
+        "name": "brightness.py",
+        "size": 4846,
+        "sha1": "edbadcc62d6e1530b2ca0529918dd6de6ff76a36",
+        "fingerprint": "cce4efe48330c76f8636a28275a69681",
+        "original_path": "src/jarabe/model/brightness.py",
         "licenses": [],
         "copyrights": []
       }
@@ -1769,24 +1740,24 @@
       ],
       "score": 36,
       "new": {
-        "path": "src/jarabe/desktop/activitieslist.py",
+        "path": "src/jarabe/view/cursortracker.py",
         "type": "file",
-        "name": "activitieslist.py",
-        "size": 28491,
-        "sha1": "73c0c09da8495d7d08a37462c35cac21f9f2cee7",
-        "fingerprint": "91a06fba1b500bb8e3a7e7a10431b132",
-        "original_path": "src/jarabe/desktop/activitieslist.py",
+        "name": "cursortracker.py",
+        "size": 1728,
+        "sha1": "c7d296d7ea47181cb8d1a86ba6aa45e435d24e31",
+        "fingerprint": "5aaceeeac68b8d4a2a1461e266b38b60",
+        "original_path": "src/jarabe/view/cursortracker.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "src/jarabe/desktop/activitieslist.py",
+        "path": "src/jarabe/view/cursortracker.py",
         "type": "file",
-        "name": "activitieslist.py",
-        "size": 25528,
-        "sha1": "da1fe7b2b215bc9c086244b3224cb6b5ae356606",
-        "fingerprint": "93816fba1b700bf9c18786a144309172",
-        "original_path": "src/jarabe/desktop/activitieslist.py",
+        "name": "cursortracker.py",
+        "size": 1795,
+        "sha1": "b0fc71ba8210a7ac35013c91ae6bffd212be412f",
+        "fingerprint": "5aa46ee886898d4b223461e277368e20",
+        "original_path": "src/jarabe/view/cursortracker.py",
         "licenses": [],
         "copyrights": []
       }
@@ -1794,202 +1765,28 @@
     {
       "status": "modified",
       "factors": [
-        "Similar with hamming distance : 15"
+        "Similar with hamming distance : 16"
       ],
-      "score": 35,
+      "score": 36,
       "new": {
-        "path": "src/jarabe/desktop/Makefile.am",
+        "path": "src/jarabe/view/launcher.py",
         "type": "file",
-        "name": "Makefile.am",
-        "size": 437,
-        "sha1": "e632e2807fc7c4251a93b57d0024c5bff4b07a86",
-        "fingerprint": "f8efb1cbf61fd9e9665bbbe83e8f99c6",
-        "original_path": "src/jarabe/desktop/Makefile.am",
+        "name": "launcher.py",
+        "size": 6044,
+        "sha1": "9b7f24c52515bd673bc2fe86be47460107e26c9f",
+        "fingerprint": "baf5d3ea1a8a7e9e23a5e3a067b2aa18",
+        "original_path": "src/jarabe/view/launcher.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "src/jarabe/desktop/Makefile.am",
+        "path": "src/jarabe/view/launcher.py",
         "type": "file",
-        "name": "Makefile.am",
-        "size": 405,
-        "sha1": "dccfb832b731959cf8ddb390118227ef53592741",
-        "fingerprint": "f8ef21cfe617e9e96b5bbfe81e8f98ca",
-        "original_path": "src/jarabe/desktop/Makefile.am",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 15"
-      ],
-      "score": 35,
-      "new": {
-        "path": "src/jarabe/model/friends.py",
-        "type": "file",
-        "name": "friends.py",
-        "size": 5278,
-        "sha1": "f9786839cecc0a9e157144c6759b5e72aa5446dd",
-        "fingerprint": "1fa4e37a568b27502626673524f2d2aa",
-        "original_path": "src/jarabe/model/friends.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/model/friends.py",
-        "type": "file",
-        "name": "friends.py",
-        "size": 5345,
-        "sha1": "98d0a1b0aca26bbe3f3c9207c8b6cbca4acc9733",
-        "fingerprint": "5fa4e3fa56996759a626570534d2daaa",
-        "original_path": "src/jarabe/model/friends.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 15"
-      ],
-      "score": 35,
-      "new": {
-        "path": "src/jarabe/testrunner.py",
-        "type": "file",
-        "name": "testrunner.py",
-        "size": 1607,
-        "sha1": "d51cc4701b3b3c94720264a0a8063e5bccd98b5b",
-        "fingerprint": "ba70dda0e69bc50a2aa661a164a2d4a5",
-        "original_path": "src/jarabe/testrunner.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/testrunner.py",
-        "type": "file",
-        "name": "testrunner.py",
-        "size": 1674,
-        "sha1": "e0cad5658677d7ec6382c720fbc323f047319042",
-        "fingerprint": "3e705da08699c52e22a669a13ca6d4a1",
-        "original_path": "src/jarabe/testrunner.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 15"
-      ],
-      "score": 35,
-      "new": {
-        "path": "src/jarabe/model/invites.py",
-        "type": "file",
-        "name": "invites.py",
-        "size": 12064,
-        "sha1": "ce63d660616cfb35a20538428cef8ea2c858e6d8",
-        "fingerprint": "93ec6388de1ffc6a12e4e73a74e39a0d",
-        "original_path": "src/jarabe/model/invites.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/model/invites.py",
-        "type": "file",
-        "name": "invites.py",
-        "size": 11985,
-        "sha1": "b20d2ea2474bdb2ae14ab2cf6e1f0f1cdd27996f",
-        "fingerprint": "d7ec6380de3fcf6a16a4e73a75e7de05",
-        "original_path": "src/jarabe/model/invites.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 15"
-      ],
-      "score": 35,
-      "new": {
-        "path": "src/jarabe/frame/devicestray.py",
-        "type": "file",
-        "name": "devicestray.py",
-        "size": 1901,
-        "sha1": "dd7f3ed92f4622cbfe39d7b53264c9fe47a41bf7",
-        "fingerprint": "90a553b8669bc7de2e3668c165b2862c",
-        "original_path": "src/jarabe/frame/devicestray.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/frame/devicestray.py",
-        "type": "file",
-        "name": "devicestray.py",
-        "size": 1967,
-        "sha1": "efbe7112aeda0a6735d40541f29a49bd90c43016",
-        "fingerprint": "12a453b04e9bc7ff2636484135b2c624",
-        "original_path": "src/jarabe/frame/devicestray.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 15"
-      ],
-      "score": 35,
-      "new": {
-        "path": "src/jarabe/journal/modalalert.py",
-        "type": "file",
-        "name": "modalalert.py",
-        "size": 3640,
-        "sha1": "3bbd3bad617dd3e974b67cf0cba82fa7af53a0db",
-        "fingerprint": "c8e067aa0e9bef8e28dc688165fa47a4",
-        "original_path": "src/jarabe/journal/modalalert.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/journal/modalalert.py",
-        "type": "file",
-        "name": "modalalert.py",
-        "size": 3707,
-        "sha1": "2a949ddf8d3d936cd0613d24d34e9d6b5e5683fa",
-        "fingerprint": "446063a88e99cf8ea89c688065f646a4",
-        "original_path": "src/jarabe/journal/modalalert.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 15"
-      ],
-      "score": 35,
-      "new": {
-        "path": "src/jarabe/journal/journaltoolbox.py",
-        "type": "file",
-        "name": "journaltoolbox.py",
-        "size": 41932,
-        "sha1": "6d98aae400376ca1bef29ba81c59a2eec39d1d8d",
-        "fingerprint": "f8144375e499ddbefa18a6537f8e5ca1",
-        "original_path": "src/jarabe/journal/journaltoolbox.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/journal/journaltoolbox.py",
-        "type": "file",
-        "name": "journaltoolbox.py",
-        "size": 39275,
-        "sha1": "7f6339c4488e835fe35b245170b8f88cd9bc2cec",
-        "fingerprint": "fa14435dc099da9afb18a6535d8efca1",
-        "original_path": "src/jarabe/journal/journaltoolbox.py",
+        "name": "launcher.py",
+        "size": 6111,
+        "sha1": "43135df11d30021b91878c7b9a6a91aae610f407",
+        "fingerprint": "baf4c3a89a9a6a9ea7a4e38067328a90",
+        "original_path": "src/jarabe/view/launcher.py",
         "licenses": [],
         "copyrights": []
       }
@@ -2030,6 +1827,209 @@
       ],
       "score": 35,
       "new": {
+        "path": "src/jarabe/testrunner.py",
+        "type": "file",
+        "name": "testrunner.py",
+        "size": 1607,
+        "sha1": "d51cc4701b3b3c94720264a0a8063e5bccd98b5b",
+        "fingerprint": "ba70dda0e69bc50a2aa661a164a2d4a5",
+        "original_path": "src/jarabe/testrunner.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/testrunner.py",
+        "type": "file",
+        "name": "testrunner.py",
+        "size": 1674,
+        "sha1": "e0cad5658677d7ec6382c720fbc323f047319042",
+        "fingerprint": "3e705da08699c52e22a669a13ca6d4a1",
+        "original_path": "src/jarabe/testrunner.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 15"
+      ],
+      "score": 35,
+      "new": {
+        "path": "src/jarabe/desktop/Makefile.am",
+        "type": "file",
+        "name": "Makefile.am",
+        "size": 437,
+        "sha1": "e632e2807fc7c4251a93b57d0024c5bff4b07a86",
+        "fingerprint": "f8efb1cbf61fd9e9665bbbe83e8f99c6",
+        "original_path": "src/jarabe/desktop/Makefile.am",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/desktop/Makefile.am",
+        "type": "file",
+        "name": "Makefile.am",
+        "size": 405,
+        "sha1": "dccfb832b731959cf8ddb390118227ef53592741",
+        "fingerprint": "f8ef21cfe617e9e96b5bbfe81e8f98ca",
+        "original_path": "src/jarabe/desktop/Makefile.am",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 15"
+      ],
+      "score": 35,
+      "new": {
+        "path": "src/jarabe/frame/devicestray.py",
+        "type": "file",
+        "name": "devicestray.py",
+        "size": 1901,
+        "sha1": "dd7f3ed92f4622cbfe39d7b53264c9fe47a41bf7",
+        "fingerprint": "90a553b8669bc7de2e3668c165b2862c",
+        "original_path": "src/jarabe/frame/devicestray.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/frame/devicestray.py",
+        "type": "file",
+        "name": "devicestray.py",
+        "size": 1967,
+        "sha1": "efbe7112aeda0a6735d40541f29a49bd90c43016",
+        "fingerprint": "12a453b04e9bc7ff2636484135b2c624",
+        "original_path": "src/jarabe/frame/devicestray.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 15"
+      ],
+      "score": 35,
+      "new": {
+        "path": "src/jarabe/journal/journaltoolbox.py",
+        "type": "file",
+        "name": "journaltoolbox.py",
+        "size": 41932,
+        "sha1": "6d98aae400376ca1bef29ba81c59a2eec39d1d8d",
+        "fingerprint": "f8144375e499ddbefa18a6537f8e5ca1",
+        "original_path": "src/jarabe/journal/journaltoolbox.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/journal/journaltoolbox.py",
+        "type": "file",
+        "name": "journaltoolbox.py",
+        "size": 39275,
+        "sha1": "7f6339c4488e835fe35b245170b8f88cd9bc2cec",
+        "fingerprint": "fa14435dc099da9afb18a6535d8efca1",
+        "original_path": "src/jarabe/journal/journaltoolbox.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 15"
+      ],
+      "score": 35,
+      "new": {
+        "path": "src/jarabe/journal/modalalert.py",
+        "type": "file",
+        "name": "modalalert.py",
+        "size": 3640,
+        "sha1": "3bbd3bad617dd3e974b67cf0cba82fa7af53a0db",
+        "fingerprint": "c8e067aa0e9bef8e28dc688165fa47a4",
+        "original_path": "src/jarabe/journal/modalalert.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/journal/modalalert.py",
+        "type": "file",
+        "name": "modalalert.py",
+        "size": 3707,
+        "sha1": "2a949ddf8d3d936cd0613d24d34e9d6b5e5683fa",
+        "fingerprint": "446063a88e99cf8ea89c688065f646a4",
+        "original_path": "src/jarabe/journal/modalalert.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 15"
+      ],
+      "score": 35,
+      "new": {
+        "path": "src/jarabe/model/friends.py",
+        "type": "file",
+        "name": "friends.py",
+        "size": 5278,
+        "sha1": "f9786839cecc0a9e157144c6759b5e72aa5446dd",
+        "fingerprint": "1fa4e37a568b27502626673524f2d2aa",
+        "original_path": "src/jarabe/model/friends.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/model/friends.py",
+        "type": "file",
+        "name": "friends.py",
+        "size": 5345,
+        "sha1": "98d0a1b0aca26bbe3f3c9207c8b6cbca4acc9733",
+        "fingerprint": "5fa4e3fa56996759a626570534d2daaa",
+        "original_path": "src/jarabe/model/friends.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 15"
+      ],
+      "score": 35,
+      "new": {
+        "path": "src/jarabe/model/invites.py",
+        "type": "file",
+        "name": "invites.py",
+        "size": 12064,
+        "sha1": "ce63d660616cfb35a20538428cef8ea2c858e6d8",
+        "fingerprint": "93ec6388de1ffc6a12e4e73a74e39a0d",
+        "original_path": "src/jarabe/model/invites.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/model/invites.py",
+        "type": "file",
+        "name": "invites.py",
+        "size": 11985,
+        "sha1": "b20d2ea2474bdb2ae14ab2cf6e1f0f1cdd27996f",
+        "fingerprint": "d7ec6380de3fcf6a16a4e73a75e7de05",
+        "original_path": "src/jarabe/model/invites.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 15"
+      ],
+      "score": 35,
+      "new": {
         "path": "src/jarabe/view/pulsingicon.py",
         "type": "file",
         "name": "pulsingicon.py",
@@ -2048,35 +2048,6 @@
         "sha1": "5dc538a3e0163253d754ea1bd16a0a404c368705",
         "fingerprint": "d23c73ea06054bba230663e368a4d6b2",
         "original_path": "src/jarabe/view/pulsingicon.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 14"
-      ],
-      "score": 34,
-      "new": {
-        "path": "src/jarabe/journal/expandedentry.py",
-        "type": "file",
-        "name": "expandedentry.py",
-        "size": 20484,
-        "sha1": "78114bd9e62b5bc8e6be54d5d5bb8c6c48f8ea4a",
-        "fingerprint": "a804b7feddef6d24dec762d7fcaa9eaf",
-        "original_path": "src/jarabe/journal/expandedentry.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/journal/expandedentry.py",
-        "type": "file",
-        "name": "expandedentry.py",
-        "size": 20066,
-        "sha1": "b9b88193e880224cc76bfbd189ad612e4bf83a2c",
-        "fingerprint": "ac04f7f69def2126ded762e7fcaabe2d",
-        "original_path": "src/jarabe/journal/expandedentry.py",
         "licenses": [],
         "copyrights": []
       }
@@ -2117,35 +2088,6 @@
       ],
       "score": 34,
       "new": {
-        "path": "src/jarabe/util/httprange.py",
-        "type": "file",
-        "name": "httprange.py",
-        "size": 2746,
-        "sha1": "ab9c70e9dd660062a8e4463c79edd097e072e9fe",
-        "fingerprint": "9ce03ff2f21bf7624ab461b1648686b2",
-        "original_path": "src/jarabe/util/httprange.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/util/httprange.py",
-        "type": "file",
-        "name": "httprange.py",
-        "size": 2810,
-        "sha1": "54cbda4b578cb130200e6f5730eb37ad4a29ba48",
-        "fingerprint": "1ce03ff2fa5dd77a4ab4618174869eb0",
-        "original_path": "src/jarabe/util/httprange.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 14"
-      ],
-      "score": 34,
-      "new": {
         "path": "src/jarabe/frame/zoomtoolbar.py",
         "type": "file",
         "name": "zoomtoolbar.py",
@@ -2171,28 +2113,57 @@
     {
       "status": "modified",
       "factors": [
-        "Similar with hamming distance : 13"
+        "Similar with hamming distance : 14"
       ],
-      "score": 33,
+      "score": 34,
       "new": {
-        "path": "src/jarabe/view/keyhandler.py",
+        "path": "src/jarabe/journal/expandedentry.py",
         "type": "file",
-        "name": "keyhandler.py",
-        "size": 8759,
-        "sha1": "2a53e8f18abc8c2162e14c7476d20b415005e3f6",
-        "fingerprint": "c8f964e48fbaef420117a1a82ef2df28",
-        "original_path": "src/jarabe/view/keyhandler.py",
+        "name": "expandedentry.py",
+        "size": 20484,
+        "sha1": "78114bd9e62b5bc8e6be54d5d5bb8c6c48f8ea4a",
+        "fingerprint": "a804b7feddef6d24dec762d7fcaa9eaf",
+        "original_path": "src/jarabe/journal/expandedentry.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "src/jarabe/view/keyhandler.py",
+        "path": "src/jarabe/journal/expandedentry.py",
         "type": "file",
-        "name": "keyhandler.py",
-        "size": 8356,
-        "sha1": "94eeab4fa38833a52b67e065caf017ce4e43b742",
-        "fingerprint": "4af960e08bb2efc28017a1a87ff29f28",
-        "original_path": "src/jarabe/view/keyhandler.py",
+        "name": "expandedentry.py",
+        "size": 20066,
+        "sha1": "b9b88193e880224cc76bfbd189ad612e4bf83a2c",
+        "fingerprint": "ac04f7f69def2126ded762e7fcaabe2d",
+        "original_path": "src/jarabe/journal/expandedentry.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 14"
+      ],
+      "score": 34,
+      "new": {
+        "path": "src/jarabe/util/httprange.py",
+        "type": "file",
+        "name": "httprange.py",
+        "size": 2746,
+        "sha1": "ab9c70e9dd660062a8e4463c79edd097e072e9fe",
+        "fingerprint": "9ce03ff2f21bf7624ab461b1648686b2",
+        "original_path": "src/jarabe/util/httprange.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/util/httprange.py",
+        "type": "file",
+        "name": "httprange.py",
+        "size": 2810,
+        "sha1": "54cbda4b578cb130200e6f5730eb37ad4a29ba48",
+        "fingerprint": "1ce03ff2fa5dd77a4ab4618174869eb0",
+        "original_path": "src/jarabe/util/httprange.py",
         "licenses": [],
         "copyrights": []
       }
@@ -2258,28 +2229,115 @@
     {
       "status": "modified",
       "factors": [
-        "Similar with hamming distance : 12"
+        "Similar with hamming distance : 13"
       ],
-      "score": 32,
+      "score": 33,
       "new": {
-        "path": "src/jarabe/view/palettes.py",
+        "path": "src/jarabe/view/keyhandler.py",
         "type": "file",
-        "name": "palettes.py",
-        "size": 11628,
-        "sha1": "e2a5f5655204ecb2f698f0b56b6e081b1bf37e64",
-        "fingerprint": "f33dd923ffeec4ee38b4264f3fc709a1",
-        "original_path": "src/jarabe/view/palettes.py",
+        "name": "keyhandler.py",
+        "size": 8759,
+        "sha1": "2a53e8f18abc8c2162e14c7476d20b415005e3f6",
+        "fingerprint": "c8f964e48fbaef420117a1a82ef2df28",
+        "original_path": "src/jarabe/view/keyhandler.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "src/jarabe/view/palettes.py",
+        "path": "src/jarabe/view/keyhandler.py",
         "type": "file",
-        "name": "palettes.py",
-        "size": 11344,
-        "sha1": "abc9a584cae92374067d2dad6378ae4b78ee9bee",
-        "fingerprint": "f33d59a3efeec4ee30b42e0f1dd70fa0",
-        "original_path": "src/jarabe/view/palettes.py",
+        "name": "keyhandler.py",
+        "size": 8356,
+        "sha1": "94eeab4fa38833a52b67e065caf017ce4e43b742",
+        "fingerprint": "4af960e08bb2efc28017a1a87ff29f28",
+        "original_path": "src/jarabe/view/keyhandler.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 12"
+      ],
+      "score": 32,
+      "new": {
+        "path": "src/jarabe/desktop/keydialog.py",
+        "type": "file",
+        "name": "keydialog.py",
+        "size": 10316,
+        "sha1": "bd48e8beaf21fa239668ef718b38163976d05624",
+        "fingerprint": "b8d69bfee48b588743064db6e5909f46",
+        "original_path": "src/jarabe/desktop/keydialog.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/desktop/keydialog.py",
+        "type": "file",
+        "name": "keydialog.py",
+        "size": 9991,
+        "sha1": "619ee3ea902bd2b96ca32b85d92c3ab0376b2e04",
+        "fingerprint": "50d45bfee48bd88743064da6e5911d46",
+        "original_path": "src/jarabe/desktop/keydialog.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 12"
+      ],
+      "score": 32,
+      "new": {
+        "path": "src/jarabe/frame/clipboardtray.py",
+        "type": "file",
+        "name": "clipboardtray.py",
+        "size": 7144,
+        "sha1": "dd1df8471c474c66a59c809c1e6b3daa9bf16680",
+        "fingerprint": "0efcc0ad5402ec5e4aac21d565ebdc62",
+        "original_path": "src/jarabe/frame/clipboardtray.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/frame/clipboardtray.py",
+        "type": "file",
+        "name": "clipboardtray.py",
+        "size": 7210,
+        "sha1": "6726d85aff94a228f3f47ce98c5470fc4abac680",
+        "fingerprint": "1efc40ad5412cc5ec2ac21d125e7dc20",
+        "original_path": "src/jarabe/frame/clipboardtray.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 12"
+      ],
+      "score": 32,
+      "new": {
+        "path": "src/jarabe/frame/notification.py",
+        "type": "file",
+        "name": "notification.py",
+        "size": 10970,
+        "sha1": "ca9dda15ae0bfeb14e5a9d90512bd03da93d6d61",
+        "fingerprint": "53f46d726e1807ef2ac7a0c06eaa8da4",
+        "original_path": "src/jarabe/frame/notification.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/frame/notification.py",
+        "type": "file",
+        "name": "notification.py",
+        "size": 11022,
+        "sha1": "cc23bcce63c6682ce866223b695eb0e743311b37",
+        "fingerprint": "53f46df28e1807ffaac7e1c07eea8ea4",
+        "original_path": "src/jarabe/frame/notification.py",
         "licenses": [],
         "copyrights": []
       }
@@ -2349,53 +2407,24 @@
       ],
       "score": 32,
       "new": {
-        "path": "src/jarabe/view/customizebundle.py",
+        "path": "src/jarabe/journal/objectchooser.py",
         "type": "file",
-        "name": "customizebundle.py",
-        "size": 7423,
-        "sha1": "18b063de275c737138412143a655a67f6b4bb4f2",
-        "fingerprint": "97f0c7a316536fdc6a0c60321cc585a0",
-        "original_path": "src/jarabe/view/customizebundle.py",
+        "name": "objectchooser.py",
+        "size": 8575,
+        "sha1": "667d588181c3ac7bf74f90b66620ac28ddce213f",
+        "fingerprint": "5e20ebbeeecd6fcd664221166404e782",
+        "original_path": "src/jarabe/journal/objectchooser.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "src/jarabe/view/customizebundle.py",
+        "path": "src/jarabe/journal/objectchooser.py",
         "type": "file",
-        "name": "customizebundle.py",
-        "size": 7485,
-        "sha1": "58d0a2b40e660d68be27f2d686e8ae64fbf835f9",
-        "fingerprint": "97f0c7b39e516fddaa2860321cd504a0",
-        "original_path": "src/jarabe/view/customizebundle.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 12"
-      ],
-      "score": 32,
-      "new": {
-        "path": "src/jarabe/desktop/keydialog.py",
-        "type": "file",
-        "name": "keydialog.py",
-        "size": 10316,
-        "sha1": "bd48e8beaf21fa239668ef718b38163976d05624",
-        "fingerprint": "b8d69bfee48b588743064db6e5909f46",
-        "original_path": "src/jarabe/desktop/keydialog.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/desktop/keydialog.py",
-        "type": "file",
-        "name": "keydialog.py",
-        "size": 9991,
-        "sha1": "619ee3ea902bd2b96ca32b85d92c3ab0376b2e04",
-        "fingerprint": "50d45bfee48bd88743064da6e5911d46",
-        "original_path": "src/jarabe/desktop/keydialog.py",
+        "name": "objectchooser.py",
+        "size": 8642,
+        "sha1": "b786112353a0a083abb29a58897cb0b315c114ee",
+        "fingerprint": "5e20ebbeceddcfcde63201122406e782",
+        "original_path": "src/jarabe/journal/objectchooser.py",
         "licenses": [],
         "copyrights": []
       }
@@ -2436,24 +2465,24 @@
       ],
       "score": 32,
       "new": {
-        "path": "src/jarabe/frame/notification.py",
+        "path": "src/jarabe/view/customizebundle.py",
         "type": "file",
-        "name": "notification.py",
-        "size": 10970,
-        "sha1": "ca9dda15ae0bfeb14e5a9d90512bd03da93d6d61",
-        "fingerprint": "53f46d726e1807ef2ac7a0c06eaa8da4",
-        "original_path": "src/jarabe/frame/notification.py",
+        "name": "customizebundle.py",
+        "size": 7423,
+        "sha1": "18b063de275c737138412143a655a67f6b4bb4f2",
+        "fingerprint": "97f0c7a316536fdc6a0c60321cc585a0",
+        "original_path": "src/jarabe/view/customizebundle.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "src/jarabe/frame/notification.py",
+        "path": "src/jarabe/view/customizebundle.py",
         "type": "file",
-        "name": "notification.py",
-        "size": 11022,
-        "sha1": "cc23bcce63c6682ce866223b695eb0e743311b37",
-        "fingerprint": "53f46df28e1807ffaac7e1c07eea8ea4",
-        "original_path": "src/jarabe/frame/notification.py",
+        "name": "customizebundle.py",
+        "size": 7485,
+        "sha1": "58d0a2b40e660d68be27f2d686e8ae64fbf835f9",
+        "fingerprint": "97f0c7b39e516fddaa2860321cd504a0",
+        "original_path": "src/jarabe/view/customizebundle.py",
         "licenses": [],
         "copyrights": []
       }
@@ -2465,111 +2494,24 @@
       ],
       "score": 32,
       "new": {
-        "path": "src/jarabe/frame/clipboardtray.py",
+        "path": "src/jarabe/view/palettes.py",
         "type": "file",
-        "name": "clipboardtray.py",
-        "size": 7144,
-        "sha1": "dd1df8471c474c66a59c809c1e6b3daa9bf16680",
-        "fingerprint": "0efcc0ad5402ec5e4aac21d565ebdc62",
-        "original_path": "src/jarabe/frame/clipboardtray.py",
+        "name": "palettes.py",
+        "size": 11628,
+        "sha1": "e2a5f5655204ecb2f698f0b56b6e081b1bf37e64",
+        "fingerprint": "f33dd923ffeec4ee38b4264f3fc709a1",
+        "original_path": "src/jarabe/view/palettes.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "src/jarabe/frame/clipboardtray.py",
+        "path": "src/jarabe/view/palettes.py",
         "type": "file",
-        "name": "clipboardtray.py",
-        "size": 7210,
-        "sha1": "6726d85aff94a228f3f47ce98c5470fc4abac680",
-        "fingerprint": "1efc40ad5412cc5ec2ac21d125e7dc20",
-        "original_path": "src/jarabe/frame/clipboardtray.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 12"
-      ],
-      "score": 32,
-      "new": {
-        "path": "src/jarabe/journal/objectchooser.py",
-        "type": "file",
-        "name": "objectchooser.py",
-        "size": 8575,
-        "sha1": "667d588181c3ac7bf74f90b66620ac28ddce213f",
-        "fingerprint": "5e20ebbeeecd6fcd664221166404e782",
-        "original_path": "src/jarabe/journal/objectchooser.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/journal/objectchooser.py",
-        "type": "file",
-        "name": "objectchooser.py",
-        "size": 8642,
-        "sha1": "b786112353a0a083abb29a58897cb0b315c114ee",
-        "fingerprint": "5e20ebbeceddcfcde63201122406e782",
-        "original_path": "src/jarabe/journal/objectchooser.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 11"
-      ],
-      "score": 31,
-      "new": {
-        "path": "src/jarabe/frame/eventarea.py",
-        "type": "file",
-        "name": "eventarea.py",
-        "size": 5219,
-        "sha1": "69267915b054c03b80b6abd2dd53233948f91a59",
-        "fingerprint": "5875d786ca98e4ee12e8273076a39783",
-        "original_path": "src/jarabe/frame/eventarea.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/frame/eventarea.py",
-        "type": "file",
-        "name": "eventarea.py",
-        "size": 5302,
-        "sha1": "4c0f7f9d4028480eb52bad9f150009fd1cea4414",
-        "fingerprint": "58755784cb18e4ee42e8673074a39680",
-        "original_path": "src/jarabe/frame/eventarea.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 11"
-      ],
-      "score": 31,
-      "new": {
-        "path": "src/jarabe/frame/clipboardobject.py",
-        "type": "file",
-        "name": "clipboardobject.py",
-        "size": 4306,
-        "sha1": "065aa62c7941d394ec738298bb2c97fcc83bc90e",
-        "fingerprint": "1ae463faeedbf5ce0a806f1575e35ea8",
-        "original_path": "src/jarabe/frame/clipboardobject.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/frame/clipboardobject.py",
-        "type": "file",
-        "name": "clipboardobject.py",
-        "size": 4373,
-        "sha1": "7c62b1e6d4a7ca94002663d9d869bdbe9c61e7c3",
-        "fingerprint": "1ae443ba8edbf78f82806f0575e35ea0",
-        "original_path": "src/jarabe/frame/clipboardobject.py",
+        "name": "palettes.py",
+        "size": 11344,
+        "sha1": "abc9a584cae92374067d2dad6378ae4b78ee9bee",
+        "fingerprint": "f33d59a3efeec4ee30b42e0f1dd70fa0",
+        "original_path": "src/jarabe/view/palettes.py",
         "licenses": [],
         "copyrights": []
       }
@@ -2610,24 +2552,24 @@
       ],
       "score": 31,
       "new": {
-        "path": "src/jarabe/view/gesturehandler.py",
+        "path": "src/jarabe/frame/clipboardobject.py",
         "type": "file",
-        "name": "gesturehandler.py",
-        "size": 2473,
-        "sha1": "13ec850db86f39ff6b75a83e474b58a96ecac838",
-        "fingerprint": "daf9e8e24e9bef6e2aa661f265bf9684",
-        "original_path": "src/jarabe/view/gesturehandler.py",
+        "name": "clipboardobject.py",
+        "size": 4306,
+        "sha1": "065aa62c7941d394ec738298bb2c97fcc83bc90e",
+        "fingerprint": "1ae463faeedbf5ce0a806f1575e35ea8",
+        "original_path": "src/jarabe/frame/clipboardobject.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "src/jarabe/view/gesturehandler.py",
+        "path": "src/jarabe/frame/clipboardobject.py",
         "type": "file",
-        "name": "gesturehandler.py",
-        "size": 2540,
-        "sha1": "a2077c881ed157cdb8dce55729f1c94feb98d883",
-        "fingerprint": "5a79e9a24e5bef6e2aa6612265bfde84",
-        "original_path": "src/jarabe/view/gesturehandler.py",
+        "name": "clipboardobject.py",
+        "size": 4373,
+        "sha1": "7c62b1e6d4a7ca94002663d9d869bdbe9c61e7c3",
+        "fingerprint": "1ae443ba8edbf78f82806f0575e35ea0",
+        "original_path": "src/jarabe/frame/clipboardobject.py",
         "licenses": [],
         "copyrights": []
       }
@@ -2668,24 +2610,53 @@
       ],
       "score": 31,
       "new": {
-        "path": "src/jarabe/view/service.py",
+        "path": "src/jarabe/frame/eventarea.py",
         "type": "file",
-        "name": "service.py",
-        "size": 3237,
-        "sha1": "b6ec741d8b3a269dd9db610635fdc75d3a988bc4",
-        "fingerprint": "f2eccbd4eebbcf41222661d064ea9eb6",
-        "original_path": "src/jarabe/view/service.py",
+        "name": "eventarea.py",
+        "size": 5219,
+        "sha1": "69267915b054c03b80b6abd2dd53233948f91a59",
+        "fingerprint": "5875d786ca98e4ee12e8273076a39783",
+        "original_path": "src/jarabe/frame/eventarea.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "src/jarabe/view/service.py",
+        "path": "src/jarabe/frame/eventarea.py",
         "type": "file",
-        "name": "service.py",
-        "size": 3304,
-        "sha1": "11d6c794f293f0fdc174e3d9caa9373567683028",
-        "fingerprint": "f2ec4b94eeb9cf61823671c074ea9ea6",
-        "original_path": "src/jarabe/view/service.py",
+        "name": "eventarea.py",
+        "size": 5302,
+        "sha1": "4c0f7f9d4028480eb52bad9f150009fd1cea4414",
+        "fingerprint": "58755784cb18e4ee42e8673074a39680",
+        "original_path": "src/jarabe/frame/eventarea.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 11"
+      ],
+      "score": 31,
+      "new": {
+        "path": "src/jarabe/view/gesturehandler.py",
+        "type": "file",
+        "name": "gesturehandler.py",
+        "size": 2473,
+        "sha1": "13ec850db86f39ff6b75a83e474b58a96ecac838",
+        "fingerprint": "daf9e8e24e9bef6e2aa661f265bf9684",
+        "original_path": "src/jarabe/view/gesturehandler.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/view/gesturehandler.py",
+        "type": "file",
+        "name": "gesturehandler.py",
+        "size": 2540,
+        "sha1": "a2077c881ed157cdb8dce55729f1c94feb98d883",
+        "fingerprint": "5a79e9a24e5bef6e2aa6612265bfde84",
+        "original_path": "src/jarabe/view/gesturehandler.py",
         "licenses": [],
         "copyrights": []
       }
@@ -2722,28 +2693,28 @@
     {
       "status": "modified",
       "factors": [
-        "Similar with hamming distance : 10"
+        "Similar with hamming distance : 11"
       ],
-      "score": 30,
+      "score": 31,
       "new": {
-        "path": "src/jarabe/model/screenshot.py",
+        "path": "src/jarabe/view/service.py",
         "type": "file",
-        "name": "screenshot.py",
-        "size": 3989,
-        "sha1": "fa06fba647be031477b743088dbfb0be9abe669f",
-        "fingerprint": "d82167a274fb85cda2ae899076e2a4ec",
-        "original_path": "src/jarabe/model/screenshot.py",
+        "name": "service.py",
+        "size": 3237,
+        "sha1": "b6ec741d8b3a269dd9db610635fdc75d3a988bc4",
+        "fingerprint": "f2eccbd4eebbcf41222661d064ea9eb6",
+        "original_path": "src/jarabe/view/service.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "src/jarabe/model/screenshot.py",
+        "path": "src/jarabe/view/service.py",
         "type": "file",
-        "name": "screenshot.py",
-        "size": 4056,
-        "sha1": "127baebbdbefb486d93dbca963e5ac9df77dcf30",
-        "fingerprint": "582067a2f4f985cda2aec9803662acac",
-        "original_path": "src/jarabe/model/screenshot.py",
+        "name": "service.py",
+        "size": 3304,
+        "sha1": "11d6c794f293f0fdc174e3d9caa9373567683028",
+        "fingerprint": "f2ec4b94eeb9cf61823671c074ea9ea6",
+        "original_path": "src/jarabe/view/service.py",
         "licenses": [],
         "copyrights": []
       }
@@ -2842,6 +2813,35 @@
       ],
       "score": 30,
       "new": {
+        "path": "src/jarabe/model/screenshot.py",
+        "type": "file",
+        "name": "screenshot.py",
+        "size": 3989,
+        "sha1": "fa06fba647be031477b743088dbfb0be9abe669f",
+        "fingerprint": "d82167a274fb85cda2ae899076e2a4ec",
+        "original_path": "src/jarabe/model/screenshot.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/model/screenshot.py",
+        "type": "file",
+        "name": "screenshot.py",
+        "size": 4056,
+        "sha1": "127baebbdbefb486d93dbca963e5ac9df77dcf30",
+        "fingerprint": "582067a2f4f985cda2aec9803662acac",
+        "original_path": "src/jarabe/model/screenshot.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 10"
+      ],
+      "score": 30,
+      "new": {
         "path": "src/jarabe/view/viewsource.py",
         "type": "file",
         "name": "viewsource.py",
@@ -2871,53 +2871,24 @@
       ],
       "score": 29,
       "new": {
-        "path": "src/jarabe/model/update/microformat.py",
+        "path": "src/jarabe/desktop/favoriteslayout.py",
         "type": "file",
-        "name": "microformat.py",
-        "size": 16823,
-        "sha1": "81cc0a1de95ac4c9b204d4f7e19474a46ff8c793",
-        "fingerprint": "d34578f85c07e55f2e3478aa2cc23d02",
-        "original_path": "src/jarabe/model/update/microformat.py",
+        "name": "favoriteslayout.py",
+        "size": 24400,
+        "sha1": "2d778d406c92fe26808240435d10d19dd9d07cc3",
+        "fingerprint": "53300d9ce0d3c414ca06a9b9f6a5ed21",
+        "original_path": "src/jarabe/desktop/favoriteslayout.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "src/jarabe/model/update/microformat.py",
+        "path": "src/jarabe/desktop/favoriteslayout.py",
         "type": "file",
-        "name": "microformat.py",
-        "size": 16888,
-        "sha1": "c26ab32f5395edebdcd47fd13b51d3dc550e7672",
-        "fingerprint": "d74568985c15e57f2e3078aa2cc21d02",
-        "original_path": "src/jarabe/model/update/microformat.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 9"
-      ],
-      "score": 29,
-      "new": {
-        "path": "src/jarabe/desktop/snowflakelayout.py",
-        "type": "file",
-        "name": "snowflakelayout.py",
-        "size": 4462,
-        "sha1": "1dfebdc586bea6d8abb2d8d2c287453242deb241",
-        "fingerprint": "18e1e3cac0a9aeef3006f9b3650a15b9",
-        "original_path": "src/jarabe/desktop/snowflakelayout.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/desktop/snowflakelayout.py",
-        "type": "file",
-        "name": "snowflakelayout.py",
-        "size": 4529,
-        "sha1": "5c362e20e8c336ffee9a1c123e8c28c263743ac7",
-        "fingerprint": "1861c3cac0b9aeef2006d8b3750a14a9",
-        "original_path": "src/jarabe/desktop/snowflakelayout.py",
+        "name": "favoriteslayout.py",
+        "size": 24362,
+        "sha1": "677f2bddd9713ce7bbb5c76cb02215f731ead3e9",
+        "fingerprint": "53300f9ce0d3c4944a8ea9b1b625ec21",
+        "original_path": "src/jarabe/desktop/favoriteslayout.py",
         "licenses": [],
         "copyrights": []
       }
@@ -2958,6 +2929,64 @@
       ],
       "score": 29,
       "new": {
+        "path": "src/jarabe/desktop/snowflakelayout.py",
+        "type": "file",
+        "name": "snowflakelayout.py",
+        "size": 4462,
+        "sha1": "1dfebdc586bea6d8abb2d8d2c287453242deb241",
+        "fingerprint": "18e1e3cac0a9aeef3006f9b3650a15b9",
+        "original_path": "src/jarabe/desktop/snowflakelayout.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/desktop/snowflakelayout.py",
+        "type": "file",
+        "name": "snowflakelayout.py",
+        "size": 4529,
+        "sha1": "5c362e20e8c336ffee9a1c123e8c28c263743ac7",
+        "fingerprint": "1861c3cac0b9aeef2006d8b3750a14a9",
+        "original_path": "src/jarabe/desktop/snowflakelayout.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 9"
+      ],
+      "score": 29,
+      "new": {
+        "path": "src/jarabe/model/update/microformat.py",
+        "type": "file",
+        "name": "microformat.py",
+        "size": 16823,
+        "sha1": "81cc0a1de95ac4c9b204d4f7e19474a46ff8c793",
+        "fingerprint": "d34578f85c07e55f2e3478aa2cc23d02",
+        "original_path": "src/jarabe/model/update/microformat.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/model/update/microformat.py",
+        "type": "file",
+        "name": "microformat.py",
+        "size": 16888,
+        "sha1": "c26ab32f5395edebdcd47fd13b51d3dc550e7672",
+        "fingerprint": "d74568985c15e57f2e3078aa2cc21d02",
+        "original_path": "src/jarabe/model/update/microformat.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 9"
+      ],
+      "score": 29,
+      "new": {
         "path": "src/jarabe/view/tabbinghandler.py",
         "type": "file",
         "name": "tabbinghandler.py",
@@ -2976,209 +3005,6 @@
         "sha1": "834b9990e293c0943529f04f9d25f9448c3b4504",
         "fingerprint": "522145b05ab98d2402daa7836dbac5e4",
         "original_path": "src/jarabe/view/tabbinghandler.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 9"
-      ],
-      "score": 29,
-      "new": {
-        "path": "src/jarabe/desktop/favoriteslayout.py",
-        "type": "file",
-        "name": "favoriteslayout.py",
-        "size": 24400,
-        "sha1": "2d778d406c92fe26808240435d10d19dd9d07cc3",
-        "fingerprint": "53300d9ce0d3c414ca06a9b9f6a5ed21",
-        "original_path": "src/jarabe/desktop/favoriteslayout.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/desktop/favoriteslayout.py",
-        "type": "file",
-        "name": "favoriteslayout.py",
-        "size": 24362,
-        "sha1": "677f2bddd9713ce7bbb5c76cb02215f731ead3e9",
-        "fingerprint": "53300f9ce0d3c4944a8ea9b1b625ec21",
-        "original_path": "src/jarabe/desktop/favoriteslayout.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 8"
-      ],
-      "score": 28,
-      "new": {
-        "path": "src/jarabe/frame/activitiestray.py",
-        "type": "file",
-        "name": "activitiestray.py",
-        "size": 33360,
-        "sha1": "da32c81d8eec6b9a336a8fbacf336a60b8a952ec",
-        "fingerprint": "9a85cfaac4bbbbdd5f1da0e4ffbf5f24",
-        "original_path": "src/jarabe/frame/activitiestray.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/frame/activitiestray.py",
-        "type": "file",
-        "name": "activitiestray.py",
-        "size": 33243,
-        "sha1": "9b49584976b8225911a8292a85a05b5b37e41b66",
-        "fingerprint": "9a8547aac6bbbbdd1f3da0e5fdbf5e24",
-        "original_path": "src/jarabe/frame/activitiestray.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 8"
-      ],
-      "score": 28,
-      "new": {
-        "path": "src/jarabe/journal/palettes.py",
-        "type": "file",
-        "name": "palettes.py",
-        "size": 25982,
-        "sha1": "aa59464762ed97b59c8eb9c89b4eb5ce801b7f24",
-        "fingerprint": "f87dfff26a1fc49a9617c65f44ab0760",
-        "original_path": "src/jarabe/journal/palettes.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/journal/palettes.py",
-        "type": "file",
-        "name": "palettes.py",
-        "size": 24904,
-        "sha1": "e4f4cf99721a404c37cd9506768dc1414af397c0",
-        "fingerprint": "ba7dfff26b1fc4baa617c25f54ab0760",
-        "original_path": "src/jarabe/journal/palettes.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 8"
-      ],
-      "score": 28,
-      "new": {
-        "path": "src/jarabe/util/downloader.py",
-        "type": "file",
-        "name": "downloader.py",
-        "size": 8616,
-        "sha1": "471dfa347b25cb2b5e62b117db22c9fa9227ae93",
-        "fingerprint": "d99c45a45e8b67472707a1bd76a65d53",
-        "original_path": "src/jarabe/util/downloader.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/util/downloader.py",
-        "type": "file",
-        "name": "downloader.py",
-        "size": 8609,
-        "sha1": "5575a79f590724e7b2d8a9f1086696fa66888de5",
-        "fingerprint": "d9bc45b4de8b67472727a5f576e65d53",
-        "original_path": "src/jarabe/util/downloader.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 8"
-      ],
-      "score": 28,
-      "new": {
-        "path": "src/jarabe/journal/detailview.py",
-        "type": "file",
-        "name": "detailview.py",
-        "size": 3968,
-        "sha1": "643e92e4f62b520668ee3e511d8ce9e8bd5ca422",
-        "fingerprint": "faf169b2ee89e4ed463665f564e6e6a4",
-        "original_path": "src/jarabe/journal/detailview.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/journal/detailview.py",
-        "type": "file",
-        "name": "detailview.py",
-        "size": 4034,
-        "sha1": "740131fe899ea7d2df6996f6867572a0ad4591a3",
-        "fingerprint": "7ab169b2ce89c6ed463665b56466e6a0",
-        "original_path": "src/jarabe/journal/detailview.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 8"
-      ],
-      "score": 28,
-      "new": {
-        "path": "src/jarabe/journal/volumestoolbar.py",
-        "type": "file",
-        "name": "volumestoolbar.py",
-        "size": 13220,
-        "sha1": "1bb400584046ea2a5f1bd725174754c1b494ac4e",
-        "fingerprint": "18c8e22ad09fc09a38bc24302c2e2626",
-        "original_path": "src/jarabe/journal/volumestoolbar.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/journal/volumestoolbar.py",
-        "type": "file",
-        "name": "volumestoolbar.py",
-        "size": 13278,
-        "sha1": "a3fa48fb429a64599bd72d30bd12b62619fda439",
-        "fingerprint": "10c862aad09bc0ba28bc24202c0e2626",
-        "original_path": "src/jarabe/journal/volumestoolbar.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 8"
-      ],
-      "score": 28,
-      "new": {
-        "path": "src/jarabe/model/session.py",
-        "type": "file",
-        "name": "session.py",
-        "size": 4553,
-        "sha1": "37be5fc32cb5a41cb0a487b6838031cc71cdbb22",
-        "fingerprint": "fea17fb0d29de5562286a15064b214e5",
-        "original_path": "src/jarabe/model/session.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/model/session.py",
-        "type": "file",
-        "name": "session.py",
-        "size": 4592,
-        "sha1": "6774e3df3dd1acf3088cf81e4569ab6baa98b9c5",
-        "fingerprint": "fe217bb8d29dc5460286a140643214e5",
-        "original_path": "src/jarabe/model/session.py",
         "licenses": [],
         "copyrights": []
       }
@@ -3219,24 +3045,24 @@
       ],
       "score": 28,
       "new": {
-        "path": "src/jarabe/model/olpcmesh.py",
+        "path": "src/jarabe/frame/activitiestray.py",
         "type": "file",
-        "name": "olpcmesh.py",
-        "size": 9357,
-        "sha1": "74ca9a108ec1e8a26e4151eb9035e73159becb13",
-        "fingerprint": "acb078ecd799d5603eb225e726fba4a2",
-        "original_path": "src/jarabe/model/olpcmesh.py",
+        "name": "activitiestray.py",
+        "size": 33360,
+        "sha1": "da32c81d8eec6b9a336a8fbacf336a60b8a952ec",
+        "fingerprint": "9a85cfaac4bbbbdd5f1da0e4ffbf5f24",
+        "original_path": "src/jarabe/frame/activitiestray.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "src/jarabe/model/olpcmesh.py",
+        "path": "src/jarabe/frame/activitiestray.py",
         "type": "file",
-        "name": "olpcmesh.py",
-        "size": 9432,
-        "sha1": "1c179237de023b37a59b3b700a3aaf6092e196b4",
-        "fingerprint": "acb078a8d399c1643e3225c726fba4a2",
-        "original_path": "src/jarabe/model/olpcmesh.py",
+        "name": "activitiestray.py",
+        "size": 33243,
+        "sha1": "9b49584976b8225911a8292a85a05b5b37e41b66",
+        "fingerprint": "9a8547aac6bbbbdd1f3da0e5fdbf5e24",
+        "original_path": "src/jarabe/frame/activitiestray.py",
         "licenses": [],
         "copyrights": []
       }
@@ -3273,28 +3099,173 @@
     {
       "status": "modified",
       "factors": [
-        "Similar with hamming distance : 7"
+        "Similar with hamming distance : 8"
       ],
-      "score": 27,
+      "score": 28,
       "new": {
-        "path": "src/jarabe/frame/clipboardmenu.py",
+        "path": "src/jarabe/journal/detailview.py",
         "type": "file",
-        "name": "clipboardmenu.py",
-        "size": 8708,
-        "sha1": "5f251a2676833eb3b16bd89ef8bddd98cbbd868e",
-        "fingerprint": "1af27da8c69bc4780ee064a92dba8bb2",
-        "original_path": "src/jarabe/frame/clipboardmenu.py",
+        "name": "detailview.py",
+        "size": 3968,
+        "sha1": "643e92e4f62b520668ee3e511d8ce9e8bd5ca422",
+        "fingerprint": "faf169b2ee89e4ed463665f564e6e6a4",
+        "original_path": "src/jarabe/journal/detailview.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "src/jarabe/frame/clipboardmenu.py",
+        "path": "src/jarabe/journal/detailview.py",
         "type": "file",
-        "name": "clipboardmenu.py",
-        "size": 8775,
-        "sha1": "0c540d311e6a71810b2265409bec4043b8c9e160",
-        "fingerprint": "1af65db8c69bc4788ee064a93dba8ab0",
-        "original_path": "src/jarabe/frame/clipboardmenu.py",
+        "name": "detailview.py",
+        "size": 4034,
+        "sha1": "740131fe899ea7d2df6996f6867572a0ad4591a3",
+        "fingerprint": "7ab169b2ce89c6ed463665b56466e6a0",
+        "original_path": "src/jarabe/journal/detailview.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 8"
+      ],
+      "score": 28,
+      "new": {
+        "path": "src/jarabe/journal/palettes.py",
+        "type": "file",
+        "name": "palettes.py",
+        "size": 25982,
+        "sha1": "aa59464762ed97b59c8eb9c89b4eb5ce801b7f24",
+        "fingerprint": "f87dfff26a1fc49a9617c65f44ab0760",
+        "original_path": "src/jarabe/journal/palettes.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/journal/palettes.py",
+        "type": "file",
+        "name": "palettes.py",
+        "size": 24904,
+        "sha1": "e4f4cf99721a404c37cd9506768dc1414af397c0",
+        "fingerprint": "ba7dfff26b1fc4baa617c25f54ab0760",
+        "original_path": "src/jarabe/journal/palettes.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 8"
+      ],
+      "score": 28,
+      "new": {
+        "path": "src/jarabe/journal/volumestoolbar.py",
+        "type": "file",
+        "name": "volumestoolbar.py",
+        "size": 13220,
+        "sha1": "1bb400584046ea2a5f1bd725174754c1b494ac4e",
+        "fingerprint": "18c8e22ad09fc09a38bc24302c2e2626",
+        "original_path": "src/jarabe/journal/volumestoolbar.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/journal/volumestoolbar.py",
+        "type": "file",
+        "name": "volumestoolbar.py",
+        "size": 13278,
+        "sha1": "a3fa48fb429a64599bd72d30bd12b62619fda439",
+        "fingerprint": "10c862aad09bc0ba28bc24202c0e2626",
+        "original_path": "src/jarabe/journal/volumestoolbar.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 8"
+      ],
+      "score": 28,
+      "new": {
+        "path": "src/jarabe/model/olpcmesh.py",
+        "type": "file",
+        "name": "olpcmesh.py",
+        "size": 9357,
+        "sha1": "74ca9a108ec1e8a26e4151eb9035e73159becb13",
+        "fingerprint": "acb078ecd799d5603eb225e726fba4a2",
+        "original_path": "src/jarabe/model/olpcmesh.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/model/olpcmesh.py",
+        "type": "file",
+        "name": "olpcmesh.py",
+        "size": 9432,
+        "sha1": "1c179237de023b37a59b3b700a3aaf6092e196b4",
+        "fingerprint": "acb078a8d399c1643e3225c726fba4a2",
+        "original_path": "src/jarabe/model/olpcmesh.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 8"
+      ],
+      "score": 28,
+      "new": {
+        "path": "src/jarabe/model/session.py",
+        "type": "file",
+        "name": "session.py",
+        "size": 4553,
+        "sha1": "37be5fc32cb5a41cb0a487b6838031cc71cdbb22",
+        "fingerprint": "fea17fb0d29de5562286a15064b214e5",
+        "original_path": "src/jarabe/model/session.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/model/session.py",
+        "type": "file",
+        "name": "session.py",
+        "size": 4592,
+        "sha1": "6774e3df3dd1acf3088cf81e4569ab6baa98b9c5",
+        "fingerprint": "fe217bb8d29dc5460286a140643214e5",
+        "original_path": "src/jarabe/model/session.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 8"
+      ],
+      "score": 28,
+      "new": {
+        "path": "src/jarabe/util/downloader.py",
+        "type": "file",
+        "name": "downloader.py",
+        "size": 8616,
+        "sha1": "471dfa347b25cb2b5e62b117db22c9fa9227ae93",
+        "fingerprint": "d99c45a45e8b67472707a1bd76a65d53",
+        "original_path": "src/jarabe/util/downloader.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/util/downloader.py",
+        "type": "file",
+        "name": "downloader.py",
+        "size": 8609,
+        "sha1": "5575a79f590724e7b2d8a9f1086696fa66888de5",
+        "fingerprint": "d9bc45b4de8b67472727a5f576e65d53",
+        "original_path": "src/jarabe/util/downloader.py",
         "licenses": [],
         "copyrights": []
       }
@@ -3331,86 +3302,28 @@
     {
       "status": "modified",
       "factors": [
-        "Similar with hamming distance : 6"
+        "Similar with hamming distance : 7"
       ],
-      "score": 26,
+      "score": 27,
       "new": {
-        "path": "src/jarabe/journal/model.py",
+        "path": "src/jarabe/frame/clipboardmenu.py",
         "type": "file",
-        "name": "model.py",
-        "size": 31907,
-        "sha1": "5236442a0c7816000e53c0a9abd6372dee6a7493",
-        "fingerprint": "69e145eaf4ee59977ccfac50cfa6a977",
-        "original_path": "src/jarabe/journal/model.py",
+        "name": "clipboardmenu.py",
+        "size": 8708,
+        "sha1": "5f251a2676833eb3b16bd89ef8bddd98cbbd868e",
+        "fingerprint": "1af27da8c69bc4780ee064a92dba8bb2",
+        "original_path": "src/jarabe/frame/clipboardmenu.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "src/jarabe/journal/model.py",
+        "path": "src/jarabe/frame/clipboardmenu.py",
         "type": "file",
-        "name": "model.py",
-        "size": 31898,
-        "sha1": "e1bd927b41fb2ff1436e636cce4c294d7b9808a0",
-        "fingerprint": "69e545eaf4ee59977ccfbc52cfa6ade7",
-        "original_path": "src/jarabe/journal/model.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 6"
-      ],
-      "score": 26,
-      "new": {
-        "path": "src/jarabe/model/update/updater.py",
-        "type": "file",
-        "name": "updater.py",
-        "size": 10563,
-        "sha1": "88f7186ef2cedb170f3522ffc3a80df673dd2c1e",
-        "fingerprint": "b869e7e9c588ca5a6094c8f32d83def1",
-        "original_path": "src/jarabe/model/update/updater.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/model/update/updater.py",
-        "type": "file",
-        "name": "updater.py",
-        "size": 10628,
-        "sha1": "615320a1fc20fce6235ac45c3f5f664125c228aa",
-        "fingerprint": "b069e7e9c588ca5be094c8e32dc7def1",
-        "original_path": "src/jarabe/model/update/updater.py",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "modified",
-      "factors": [
-        "Similar with hamming distance : 6"
-      ],
-      "score": 26,
-      "new": {
-        "path": "src/jarabe/model/network.py",
-        "type": "file",
-        "name": "network.py",
-        "size": 41904,
-        "sha1": "8ef19f55176aa33f73880394c4009fde5b2d3b57",
-        "fingerprint": "9e5452327e9c8359a2c20b8d47f75cb1",
-        "original_path": "src/jarabe/model/network.py",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/model/network.py",
-        "type": "file",
-        "name": "network.py",
-        "size": 39913,
-        "sha1": "77d1208d716155117c0e13f1bf614a2fb4151a15",
-        "fingerprint": "9e5453327ed88359a2c20b8d97f75cb1",
-        "original_path": "src/jarabe/model/network.py",
+        "name": "clipboardmenu.py",
+        "size": 8775,
+        "sha1": "0c540d311e6a71810b2265409bec4043b8c9e160",
+        "fingerprint": "1af65db8c69bc4788ee064a93dba8ab0",
+        "original_path": "src/jarabe/frame/clipboardmenu.py",
         "licenses": [],
         "copyrights": []
       }
@@ -3451,6 +3364,35 @@
       ],
       "score": 26,
       "new": {
+        "path": "src/jarabe/journal/model.py",
+        "type": "file",
+        "name": "model.py",
+        "size": 31907,
+        "sha1": "5236442a0c7816000e53c0a9abd6372dee6a7493",
+        "fingerprint": "69e145eaf4ee59977ccfac50cfa6a977",
+        "original_path": "src/jarabe/journal/model.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/journal/model.py",
+        "type": "file",
+        "name": "model.py",
+        "size": 31898,
+        "sha1": "e1bd927b41fb2ff1436e636cce4c294d7b9808a0",
+        "fingerprint": "69e545eaf4ee59977ccfbc52cfa6ade7",
+        "original_path": "src/jarabe/journal/model.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 6"
+      ],
+      "score": 26,
+      "new": {
         "path": "src/jarabe/model/adhoc.py",
         "type": "file",
         "name": "adhoc.py",
@@ -3469,6 +3411,64 @@
         "sha1": "7675f182ed2544c6f9b8f3272bb5ac346387eac5",
         "fingerprint": "ea8247aa065c4cfe0eec0f956ec184a9",
         "original_path": "src/jarabe/model/adhoc.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 6"
+      ],
+      "score": 26,
+      "new": {
+        "path": "src/jarabe/model/network.py",
+        "type": "file",
+        "name": "network.py",
+        "size": 41904,
+        "sha1": "8ef19f55176aa33f73880394c4009fde5b2d3b57",
+        "fingerprint": "9e5452327e9c8359a2c20b8d47f75cb1",
+        "original_path": "src/jarabe/model/network.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/model/network.py",
+        "type": "file",
+        "name": "network.py",
+        "size": 39913,
+        "sha1": "77d1208d716155117c0e13f1bf614a2fb4151a15",
+        "fingerprint": "9e5453327ed88359a2c20b8d97f75cb1",
+        "original_path": "src/jarabe/model/network.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "modified",
+      "factors": [
+        "Similar with hamming distance : 6"
+      ],
+      "score": 26,
+      "new": {
+        "path": "src/jarabe/model/update/updater.py",
+        "type": "file",
+        "name": "updater.py",
+        "size": 10563,
+        "sha1": "88f7186ef2cedb170f3522ffc3a80df673dd2c1e",
+        "fingerprint": "b869e7e9c588ca5a6094c8f32d83def1",
+        "original_path": "src/jarabe/model/update/updater.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/model/update/updater.py",
+        "type": "file",
+        "name": "updater.py",
+        "size": 10628,
+        "sha1": "615320a1fc20fce6235ac45c3f5f664125c228aa",
+        "fingerprint": "b069e7e9c588ca5be094c8e32dc7def1",
+        "original_path": "src/jarabe/model/update/updater.py",
         "licenses": [],
         "copyrights": []
       }
@@ -3592,6 +3592,33 @@
       "factors": [],
       "score": 0,
       "new": {
+        "path": "src/jarabe/Makefile.am",
+        "type": "file",
+        "name": "Makefile.am",
+        "size": 256,
+        "sha1": "1f1e3a9c93d38ab38a4d7035a8b40b7aa37572bc",
+        "fingerprint": "24899eebc22218108997aebf9a1937ae",
+        "original_path": "src/jarabe/Makefile.am",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "src/jarabe/Makefile.am",
+        "type": "file",
+        "name": "Makefile.am",
+        "size": 256,
+        "sha1": "1f1e3a9c93d38ab38a4d7035a8b40b7aa37572bc",
+        "fingerprint": "24899eebc22218108997aebf9a1937ae",
+        "original_path": "src/jarabe/Makefile.am",
+        "licenses": [],
+        "copyrights": []
+      }
+    },
+    {
+      "status": "unmodified",
+      "factors": [],
+      "score": 0,
+      "new": {
         "path": "src/jarabe/controlpanel/Makefile.am",
         "type": "file",
         "name": "Makefile.am",
@@ -3619,24 +3646,24 @@
       "factors": [],
       "score": 0,
       "new": {
-        "path": "src/jarabe/webservice/Makefile.am",
+        "path": "src/jarabe/frame/Makefile.am",
         "type": "file",
         "name": "Makefile.am",
-        "size": 112,
-        "sha1": "218824a95b6065b00ce5f275f37696d5c03e61c4",
-        "fingerprint": "2385043ee21bd23d592558160cd5b38a",
-        "original_path": "src/jarabe/webservice/Makefile.am",
+        "size": 385,
+        "sha1": "74c53cec5699857241e3f788cfa06480921ffe5e",
+        "fingerprint": "e19d1fee02feaf2842ed128eaf27b46c",
+        "original_path": "src/jarabe/frame/Makefile.am",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "src/jarabe/webservice/Makefile.am",
+        "path": "src/jarabe/frame/Makefile.am",
         "type": "file",
         "name": "Makefile.am",
-        "size": 112,
-        "sha1": "218824a95b6065b00ce5f275f37696d5c03e61c4",
-        "fingerprint": "2385043ee21bd23d592558160cd5b38a",
-        "original_path": "src/jarabe/webservice/Makefile.am",
+        "size": 385,
+        "sha1": "74c53cec5699857241e3f788cfa06480921ffe5e",
+        "fingerprint": "e19d1fee02feaf2842ed128eaf27b46c",
+        "original_path": "src/jarabe/frame/Makefile.am",
         "licenses": [],
         "copyrights": []
       }
@@ -3646,24 +3673,24 @@
       "factors": [],
       "score": 0,
       "new": {
-        "path": "src/jarabe/webservice/__init__.py",
+        "path": "src/jarabe/intro/Makefile.am",
         "type": "file",
-        "name": "__init__.py",
-        "size": 0,
-        "sha1": null,
-        "fingerprint": null,
-        "original_path": "src/jarabe/webservice/__init__.py",
+        "name": "Makefile.am",
+        "size": 135,
+        "sha1": "b1ac2f68b8959a36fdf1fd7ebdc432bbe4d89238",
+        "fingerprint": "498defa166d35abd41bd01088edcba0e",
+        "original_path": "src/jarabe/intro/Makefile.am",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "src/jarabe/webservice/__init__.py",
+        "path": "src/jarabe/intro/Makefile.am",
         "type": "file",
-        "name": "__init__.py",
-        "size": 0,
-        "sha1": null,
-        "fingerprint": null,
-        "original_path": "src/jarabe/webservice/__init__.py",
+        "name": "Makefile.am",
+        "size": 135,
+        "sha1": "b1ac2f68b8959a36fdf1fd7ebdc432bbe4d89238",
+        "fingerprint": "498defa166d35abd41bd01088edcba0e",
+        "original_path": "src/jarabe/intro/Makefile.am",
         "licenses": [],
         "copyrights": []
       }
@@ -3673,24 +3700,24 @@
       "factors": [],
       "score": 0,
       "new": {
-        "path": "src/jarabe/util/telepathy/Makefile.am",
+        "path": "src/jarabe/model/Makefile.am",
         "type": "file",
         "name": "Makefile.am",
-        "size": 111,
-        "sha1": "162644a57f08fea633dec414d02981394143cfc0",
-        "fingerprint": "e15d522ebcd3f8b1cc6e43ca1a97fe5e",
-        "original_path": "src/jarabe/util/telepathy/Makefile.am",
+        "size": 473,
+        "sha1": "4a400df1a95aaa822319795b663e460e5efe1e82",
+        "fingerprint": "e09d81380a6b02430a637947fc22f580",
+        "original_path": "src/jarabe/model/Makefile.am",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "src/jarabe/util/telepathy/Makefile.am",
+        "path": "src/jarabe/model/Makefile.am",
         "type": "file",
         "name": "Makefile.am",
-        "size": 111,
-        "sha1": "162644a57f08fea633dec414d02981394143cfc0",
-        "fingerprint": "e15d522ebcd3f8b1cc6e43ca1a97fe5e",
-        "original_path": "src/jarabe/util/telepathy/Makefile.am",
+        "size": 473,
+        "sha1": "4a400df1a95aaa822319795b663e460e5efe1e82",
+        "fingerprint": "e09d81380a6b02430a637947fc22f580",
+        "original_path": "src/jarabe/model/Makefile.am",
         "licenses": [],
         "copyrights": []
       }
@@ -3754,24 +3781,24 @@
       "factors": [],
       "score": 0,
       "new": {
-        "path": "src/jarabe/model/Makefile.am",
+        "path": "src/jarabe/util/telepathy/Makefile.am",
         "type": "file",
         "name": "Makefile.am",
-        "size": 473,
-        "sha1": "4a400df1a95aaa822319795b663e460e5efe1e82",
-        "fingerprint": "e09d81380a6b02430a637947fc22f580",
-        "original_path": "src/jarabe/model/Makefile.am",
+        "size": 111,
+        "sha1": "162644a57f08fea633dec414d02981394143cfc0",
+        "fingerprint": "e15d522ebcd3f8b1cc6e43ca1a97fe5e",
+        "original_path": "src/jarabe/util/telepathy/Makefile.am",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "src/jarabe/model/Makefile.am",
+        "path": "src/jarabe/util/telepathy/Makefile.am",
         "type": "file",
         "name": "Makefile.am",
-        "size": 473,
-        "sha1": "4a400df1a95aaa822319795b663e460e5efe1e82",
-        "fingerprint": "e09d81380a6b02430a637947fc22f580",
-        "original_path": "src/jarabe/model/Makefile.am",
+        "size": 111,
+        "sha1": "162644a57f08fea633dec414d02981394143cfc0",
+        "fingerprint": "e15d522ebcd3f8b1cc6e43ca1a97fe5e",
+        "original_path": "src/jarabe/util/telepathy/Makefile.am",
         "licenses": [],
         "copyrights": []
       }
@@ -3781,24 +3808,24 @@
       "factors": [],
       "score": 0,
       "new": {
-        "path": "src/jarabe/intro/Makefile.am",
+        "path": "src/jarabe/webservice/__init__.py",
         "type": "file",
-        "name": "Makefile.am",
-        "size": 135,
-        "sha1": "b1ac2f68b8959a36fdf1fd7ebdc432bbe4d89238",
-        "fingerprint": "498defa166d35abd41bd01088edcba0e",
-        "original_path": "src/jarabe/intro/Makefile.am",
+        "name": "__init__.py",
+        "size": 0,
+        "sha1": null,
+        "fingerprint": null,
+        "original_path": "src/jarabe/webservice/__init__.py",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "src/jarabe/intro/Makefile.am",
+        "path": "src/jarabe/webservice/__init__.py",
         "type": "file",
-        "name": "Makefile.am",
-        "size": 135,
-        "sha1": "b1ac2f68b8959a36fdf1fd7ebdc432bbe4d89238",
-        "fingerprint": "498defa166d35abd41bd01088edcba0e",
-        "original_path": "src/jarabe/intro/Makefile.am",
+        "name": "__init__.py",
+        "size": 0,
+        "sha1": null,
+        "fingerprint": null,
+        "original_path": "src/jarabe/webservice/__init__.py",
         "licenses": [],
         "copyrights": []
       }
@@ -3808,51 +3835,24 @@
       "factors": [],
       "score": 0,
       "new": {
-        "path": "src/jarabe/frame/Makefile.am",
+        "path": "src/jarabe/webservice/Makefile.am",
         "type": "file",
         "name": "Makefile.am",
-        "size": 385,
-        "sha1": "74c53cec5699857241e3f788cfa06480921ffe5e",
-        "fingerprint": "e19d1fee02feaf2842ed128eaf27b46c",
-        "original_path": "src/jarabe/frame/Makefile.am",
+        "size": 112,
+        "sha1": "218824a95b6065b00ce5f275f37696d5c03e61c4",
+        "fingerprint": "2385043ee21bd23d592558160cd5b38a",
+        "original_path": "src/jarabe/webservice/Makefile.am",
         "licenses": [],
         "copyrights": []
       },
       "old": {
-        "path": "src/jarabe/frame/Makefile.am",
+        "path": "src/jarabe/webservice/Makefile.am",
         "type": "file",
         "name": "Makefile.am",
-        "size": 385,
-        "sha1": "74c53cec5699857241e3f788cfa06480921ffe5e",
-        "fingerprint": "e19d1fee02feaf2842ed128eaf27b46c",
-        "original_path": "src/jarabe/frame/Makefile.am",
-        "licenses": [],
-        "copyrights": []
-      }
-    },
-    {
-      "status": "unmodified",
-      "factors": [],
-      "score": 0,
-      "new": {
-        "path": "src/jarabe/Makefile.am",
-        "type": "file",
-        "name": "Makefile.am",
-        "size": 256,
-        "sha1": "1f1e3a9c93d38ab38a4d7035a8b40b7aa37572bc",
-        "fingerprint": "24899eebc22218108997aebf9a1937ae",
-        "original_path": "src/jarabe/Makefile.am",
-        "licenses": [],
-        "copyrights": []
-      },
-      "old": {
-        "path": "src/jarabe/Makefile.am",
-        "type": "file",
-        "name": "Makefile.am",
-        "size": 256,
-        "sha1": "1f1e3a9c93d38ab38a4d7035a8b40b7aa37572bc",
-        "fingerprint": "24899eebc22218108997aebf9a1937ae",
-        "original_path": "src/jarabe/Makefile.am",
+        "size": 112,
+        "sha1": "218824a95b6065b00ce5f275f37696d5c03e61c4",
+        "fingerprint": "2385043ee21bd23d592558160cd5b38a",
+        "original_path": "src/jarabe/webservice/Makefile.am",
         "licenses": [],
         "copyrights": []
       }


### PR DESCRIPTION
In this Pr I [changed](https://github.com/nexB/deltacode/blob/677888237fb2c6d6d1e2e417319921f03862af8e/src/deltacode/models.py#L158) the `Dict` to `OrderedDict` when we are making the index files.

### I changed this because :
1.To make the deltas to appear in the manner in which it is present in the scancode scans,Currently the deltas are appearing in a jumbled order.
Example:  a delta having a new file path as `src/jarabe/view/viewhelp_webkit2.py`([link](https://github.com/nexB/deltacode/blob/677888237fb2c6d6d1e2e417319921f03862af8e/tests/data/deltacode/sugar-expected.json#L37)) is appearing before a delta having a path as `src/jarabe/view/viewhelp_webkit1.py`([link](https://github.com/nexB/deltacode/blob/677888237fb2c6d6d1e2e417319921f03862af8e/tests/data/deltacode/sugar-expected.json#L54)), the paths are not arranged properly.It would look better if **deltas are arranged as per their paths in an top-down fashion of their paths**
2.Moreover when we will port deltacode to python3 then `Dict` by default places the keys as if they appear sorted by insertion order, In Python 2 `Dict` places the keys in jumbled order.However **using `Ordered Dict` will restore the uniformity in both Py2 and Py3.**  [ref](https://portingguide.readthedocs.io/en/latest/dicts.html)
**If we do not use ordered dict we may fail for some test cases when we are using py2 in CI 's**
  