### PR TITLE
added the appveyor build for Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,12 @@
+environment:
+    matrix:
+        - TEST_SUITE: "py.test "
+
+install:
+    - ./configure
+
+build: off
+
+
+test_script:
+    - cmd: "%TEST_SUITE%"

--- a/src/deltacode/test_utils.py
+++ b/src/deltacode/test_utils.py
@@ -46,8 +46,8 @@ def run_scan_click(options, monkeypatch=None, test_mode=True, expected_rc=0, env
     from click.testing import CliRunner
     from deltacode import cli
 
-    options = add_windows_extra_timeout(options)
-
+    # options = add_windows_extra_timeout(options)
+# we do not have the option to handle --timeout in deltacode so temporarily removing it
     if monkeypatch:
         monkeypatch.setattr(click._termui_impl, 'isatty', lambda _: True)
         monkeypatch.setattr(click , 'get_terminal_size', lambda : (80, 43,))


### PR DESCRIPTION
In this PR I have added the appveyor builds for Ubuntu 18.04LTS.
The link to the [logs](https://drive.google.com/drive/folders/1ajWivCoL_lFFwryqTodu5NhAU40EuVRK?usp=sharing)