### PR TITLE
changed dict.iteritems() to dict.items() (for making it Py3 compatible)

### DIFF
--- a/src/deltacode/__init__.py
+++ b/src/deltacode/__init__.py
@@ -195,9 +195,8 @@ class DeltaCode(object):
         added = self.index_deltas('sha1', [i for i in self.deltas if i.old_file is None and i.new_file])
         removed = self.index_deltas('sha1', [i for i in self.deltas if i.old_file and i.new_file is None])
 
-        # TODO: should it be iteritems() or items()
-        for added_sha1, added_deltas in added.iteritems():
-            for removed_sha1, removed_deltas in removed.iteritems():
+        for added_sha1, added_deltas in added.items():
+            for removed_sha1, removed_deltas in removed.items():
 
                 # check for matching sha1s on both sides
                 if utils.check_moved(added_sha1, added_deltas, removed_sha1, removed_deltas):

--- a/src/deltacode/cli.py
+++ b/src/deltacode/cli.py
@@ -69,7 +69,7 @@ def print_version(ctx, param, value):
 @click.option('--version', is_flag=True, is_eager=True, expose_value=False, callback=print_version, help='Show the version and exit.')
 @click.option('-n', '--new', required=True, prompt=False, type=click.Path(exists=True, readable=True), help='Identify the path to the "new" scan file')
 @click.option('-o', '--old', required=True, prompt=False, type=click.Path(exists=True, readable=True), help='Identify the path to the "old" scan file')
-@click.option('-j', '--json-file', prompt=False, default='-', type=click.File(mode='wb', lazy=False), help='Identify the path to the .json output file')
+@click.option('-j', '--json-file', prompt=False, default='-', type=click.File(mode='w', lazy=False), help='Identify the path to the .json output file')
 @click.option('-a', '--all-delta-types', is_flag=True, help="Include unmodified files as well as all changed files in the .json output.  If not selected, only changed files are included.")
 def cli(new, old, json_file, all_delta_types):
     """


### PR DESCRIPTION
In this PR I changed `.iteritems()` to `.items()` and changed the the file opening mode to `w` instead of `wb` in `cli.py`.
**I did this changes because**
1.Python3 removed the `dict.iteritems()` to `dict.items()` [references](https://wiki.python.org/moin/Python3.0#Built-In_Changes)

2.I made the 2nd change i.e. changed the file mode from `wb` to `w`as because in Py 3, with `wb` file mode the only serializable objects can be written , but actually we are writing `str` objects, Now this changed could also be done , by changing every `str` objects to `bytes stream` , which would be a lot more messy.So I changed the opening file mode to `w` which can take `str` objects for `write` operation.

The references I took for this is a Medium blog: [link](https://medium.com/better-programming/strings-unicode-and-bytes-in-python-3-everything-you-always-wanted-to-know-27dc02ff2686)
