### PR TITLE
prefers python2.7 during configuration

### DIFF
--- a/configure
+++ b/configure
@@ -25,7 +25,16 @@ fi
 CONFIGURE_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 if [[ "$PYTHON_EXE" == "" ]]; then
-    PYTHON_EXE=python
+    PYTHON_EXE=$(which python2 || true)
+fi
+
+if [[ "$PYTHON_EXE" == "" ]]; then
+    echo You should have Python2.7 installed to configure deltacode
+    exit_code=1
+    if [ $exit_code -ne 0 ]; then
+        echo "configure command failed with exit code ${exit_code}."
+        exit $exit_code
+    fi
 fi
 
 $PYTHON_EXE "$CONFIGURE_ROOT_DIR/etc/configure.py" $CFG_CMD_LINE_ARGS


### PR DESCRIPTION
This PR is meant to prefer the use of python2.7 during the configuration.
**Reason for creating this PR**
When we are having several versions of Python installed (like `python2.7 , python3.6 , conda packages,python3.7`), then the during the configuration the exact python version may not be picked up (which is `python2.7`) , In such a case then we face a version mismatch for some of the `.whl` packages during the configuration, as a result incomplete `lib` directories will be created(as a result of failure), which is not all anticipated.
