### PR TITLE
Fix CI tests

### DIFF
--- a/configure.bat
+++ b/configure.bat
@@ -89,7 +89,7 @@ call mkdir "%CFG_ROOT_DIR%tmp"
 call curl -o "%CFG_ROOT_DIR%tmp\virtualenv.pyz" https://bootstrap.pypa.io/virtualenv.pyz
 call %PYTHON_EXECUTABLE% "%CFG_ROOT_DIR%tmp\virtualenv.pyz" "%CFG_ROOT_DIR%tmp"
 call "%CFG_ROOT_DIR%tmp\Scripts\activate"
-call "%CFG_ROOT_DIR%tmp\Scripts\pip" install --upgrade pip virtualenv setuptools wheel
+call "%PYTHON_EXECUTABLE%" -m pip install --upgrade pip virtualenv setuptools wheel
 call "%CFG_ROOT_DIR%tmp\Scripts\pip" install -e .[testing]
 
 @rem Return a proper return code on failure

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,6 +39,7 @@ from deltacode import cli
 from deltacode import DeltaCode
 from deltacode import utils
 
+TERMINAL_WIDTH = 1000
 
 def load_csv(location):
     """
@@ -82,7 +83,7 @@ class TestCLI(FileBasedTesting):
         result_file = self.get_temp_file('json')
 
         runner = CliRunner()
-        result = runner.invoke(cli.cli, ['-n', new_scan, '-o',  old_scan, '-j', result_file, '-a'])
+        result = runner.invoke(cli.cli, ['-n', new_scan, '-o',  old_scan, '-j', result_file, '-a'], terminal_width=TERMINAL_WIDTH)
 
         assert result.exit_code == 0
 
@@ -248,7 +249,7 @@ class TestCLI(FileBasedTesting):
         result_file = self.get_temp_file('json')
 
         runner = CliRunner()
-        result = runner.invoke(cli.cli, ['-n', new_scan, '-o',  old_scan, '-j', result_file])
+        result = runner.invoke(cli.cli, ['-n', new_scan, '-o',  old_scan, '-j', result_file], terminal_width=TERMINAL_WIDTH)
 
         assert result.exit_code == 0
 
@@ -350,7 +351,7 @@ class TestCLI(FileBasedTesting):
         old_scan = self.get_test_loc('cli/scan_1_file_moved_old.json')
 
         runner = CliRunner()
-        result = runner.invoke(cli.cli, ['-n', new_scan, '-o',  old_scan, '-a'])
+        result = runner.invoke(cli.cli, ['-n', new_scan, '-o',  old_scan, '-a'], terminal_width=TERMINAL_WIDTH)
 
         assert result.exit_code == 0
 
@@ -392,7 +393,7 @@ class TestCLI(FileBasedTesting):
         old_scan = self.get_test_loc('cli/scan_1_file_moved_old.json')
 
         runner = CliRunner()
-        result = runner.invoke(cli.cli, ['-n', new_scan, '-o',  old_scan])
+        result = runner.invoke(cli.cli, ['-n', new_scan, '-o',  old_scan], terminal_width=TERMINAL_WIDTH)
 
         assert result.exit_code == 0
 
@@ -434,7 +435,7 @@ class TestCLI(FileBasedTesting):
         result_file = self.get_temp_file('json')
 
         runner = CliRunner()
-        result = runner.invoke(cli.cli, ['-n', new_scan, '-o',  old_scan, '-j', result_file, '-a'])
+        result = runner.invoke(cli.cli, ['-n', new_scan, '-o',  old_scan, '-j', result_file, '-a'], terminal_width=TERMINAL_WIDTH)
 
         json_result = json.load(open(result_file))
 
@@ -447,7 +448,7 @@ class TestCLI(FileBasedTesting):
         result_file = self.get_temp_file('json')
 
         runner = CliRunner()
-        result = runner.invoke(cli.cli, ['-n', new_scan, '-o',  old_scan, '-j', result_file])
+        result = runner.invoke(cli.cli, ['-n', new_scan, '-o',  old_scan, '-j', result_file], terminal_width=TERMINAL_WIDTH)
 
         json_result = json.load(open(result_file))
 
@@ -455,7 +456,7 @@ class TestCLI(FileBasedTesting):
 
     def test_help(self):
         runner = CliRunner()
-        result = runner.invoke(cli.cli, ['--help'])
+        result = runner.invoke(cli.cli, ['--help'], terminal_width=TERMINAL_WIDTH)
 
         assert 'Usage: cli [OPTIONS]' in result.output
         assert 'Identify the changes that need to be made' in result.output
@@ -465,19 +466,19 @@ class TestCLI(FileBasedTesting):
 
     def test_version(self):
         runner = CliRunner()
-        result = runner.invoke(cli.cli, ['--version'])
+        result = runner.invoke(cli.cli, ['--version'], terminal_width=TERMINAL_WIDTH)
 
         assert 'DeltaCode version' in result.output
 
     def test_empty(self):
         runner = CliRunner()
-        result = runner.invoke(cli.cli, [])
+        result = runner.invoke(cli.cli, [], terminal_width=TERMINAL_WIDTH)
         
         assert 'Usage: cli [OPTIONS]' in result.output
         assert "Error: Missing option '-n' / '--new'." in result.output
 
     def test_incorrect_flag(self):
         runner = CliRunner()
-        result = runner.invoke(cli.cli, ['-xyz'])
+        result = runner.invoke(cli.cli, ['-xyz'], terminal_width=TERMINAL_WIDTH)
 
-        assert 'Error: no such option: -x' in result.output
+        assert 'Error: No such option: -x' in result.output


### PR DESCRIPTION
Fix click library pytest issues
---
  
The update in click library by 8d49e14 in https://github.com/pallets/click/pull/1829 produces two artifacts in our codebase which caused the CI tests to fail

1) Capitalization of `N` in `No such option` 
2) Wrapping `help` so as to break line on terminal width This is solved by using an arbitrarily large `TERMINAL_WIDTH=1000`

`2` could be improved after https://github.com/pallets/click/issues/1997

---

Fix CI [WinError 5] Access is denied
---
Windows doesn't allow changing the running executable. https://github.com/pypa/pip/issues/1299#issuecomment-27809600
It worked for so long because earlier pip versions provided by azure
were already the latest ones and `--upgrade` did not modify the running
pip. Now, suddenly a new pip was released which was not present in Azure
windows and the `--upgrade pip` was triggered modifying the very
executable it is running.
Why does it say "Access is denied" (a permission error) is a mystery yet
to be unrevealed by Microsoft folks.

That said, untouched, this bug would have disappeared (when Azure
updates the pip version) and reappeared again and again haunting us for
long. No more.


Signed-off-by: Hritik Vijay <hritikxx8@gmail.com>


