### PR TITLE
Add scancode options in deltacode results

### DIFF
--- a/expected.json
+++ b/expected.json
@@ -1,0 +1,65 @@
+{
+  "deltacode_notice": "Generated with DeltaCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nDeltaCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nDeltaCode is a free software codebase-comparison tool from nexB Inc. and others.\nVisit https://github.com/nexB/deltacode/ for support and download.",
+  "new_scan_options": {
+    "input": [
+      "/home/arnav-mandal1234/Downloads/coala-0.10.0/coalib/"
+    ],
+    "--fingerprint": true,
+    "--info": true,
+    "--json-pp": "o.json"
+  },
+  "old_scan_options": {
+    "input": [
+      "/home/arnav-mandal1234/Downloads/coala-0.10.0/coalib/"
+    ],
+    "--fingerprint": true,
+    "--info": true,
+    "--json-pp": "o.json"
+  },
+  "deltacode_options": {
+    "--new": "tests/data/deltacode/scancode_options_new.json",
+    "--old": "tests/data/deltacode/scancode_options_old.json",
+    "--all-delta-types": false
+  },
+  "deltacode_version": "1.0.1.dev112+gde3c583.d20210613",
+  "deltacode_errors": [],
+  "deltas_count": 1,
+  "delta_stats": {
+    "old_files_count": 1,
+    "new_files_count": 1,
+    "percent_added": 0.0,
+    "percent_removed": 0.0,
+    "percent_moved": 0.0,
+    "percent_modified": 100.0,
+    "percent_unmodified": 0.0
+  },
+  "deltas": [
+    {
+      "status": "modified",
+      "factors": [],
+      "score": 20,
+      "new": {
+        "path": "coalib/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 587,
+        "sha1": "8fc64c86979if8cec0758cfe0fe92d85b219ac49",
+        "fingerprint": "",
+        "original_path": "coalib/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      },
+      "old": {
+        "path": "coalib/__init__.py",
+        "type": "file",
+        "name": "__init__.py",
+        "size": 587,
+        "sha1": "8fc64c86979bf8cec0758cfe0fe92d85b219ac49",
+        "fingerprint": "",
+        "original_path": "coalib/__init__.py",
+        "licenses": [],
+        "copyrights": []
+      }
+    }
+  ]
+}

--- a/src/deltacode/cli.py
+++ b/src/deltacode/cli.py
@@ -44,8 +44,8 @@ def write_json(deltacode, outfile, all_delta_types=False):
     """
     results = OrderedDict([
         ('deltacode_notice', get_notice()),
-        # ('new_scan_options', deltacode.new_scan_options),
-        # ('old_scan_options', deltacode.old_scan_options),
+        ('new_scan_options', deltacode.new_scan_options),
+        ('old_scan_options', deltacode.old_scan_options),
         ('deltacode_options', deltacode.options),
         ('deltacode_version', __version__),
         ('deltacode_errors', collect_errors(deltacode)),

--- a/tests/data/deltacode/coala-expected-result.json
+++ b/tests/data/deltacode/coala-expected-result.json
@@ -1,5 +1,21 @@
 {
   "deltacode_notice": "Generated with DeltaCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nDeltaCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nDeltaCode is a free software codebase-comparison tool from nexB Inc. and others.\nVisit https://github.com/nexB/deltacode/ for support and download.",
+  "new_scan_options": {
+    "input": [
+      "/home/arnav-mandal1234/Downloads/coala-0.10.0/coalib/"
+    ],
+    "--fingerprint": true,
+    "--info": true,
+    "--json-pp": "o.json"
+  },
+  "old_scan_options": {
+    "input": [
+      "/home/arnav-mandal1234/Downloads/coala-0.7.0/coalib/"
+    ],
+    "--fingerprint": true,
+    "--info": true,
+    "--json-pp": "o.json"
+  },
   "deltacode_options": {
     "--new": "tests/data/deltacode/coala-0.10.0-new.json",
     "--old": "tests/data/deltacode/coala-0.7.0-old.json",

--- a/tests/data/deltacode/scancode_options_expected.json
+++ b/tests/data/deltacode/scancode_options_expected.json
@@ -1,0 +1,66 @@
+{
+    "deltacode_notice": "Generated with DeltaCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nDeltaCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nDeltaCode is a free software codebase-comparison tool from nexB Inc. and others.\nVisit https://github.com/nexB/deltacode/ for support and download.",
+    "new_scan_options": {
+      "input": [
+        "/home/arnav-mandal1234/Downloads/coala-0.10.0/coalib/"
+      ],
+      "--fingerprint": true,
+      "--info": true,
+      "--json-pp": "o.json"
+    },
+    "old_scan_options": {
+      "input": [
+        "/home/arnav-mandal1234/Downloads/coala-0.10.0/coalib/"
+      ],
+      "--fingerprint": true,
+      "--info": true,
+      "--json-pp": "o.json"
+    },
+    "deltacode_options": {
+      "--new": "tests/data/deltacode/scancode_options_new.json",
+      "--old": "tests/data/deltacode/scancode_options_old.json",
+      "--all-delta-types": false
+    },
+    "deltacode_version": "1.0.1.dev112+gde3c583.d20210613",
+    "deltacode_errors": [],
+    "deltas_count": 1,
+    "delta_stats": {
+      "old_files_count": 1,
+      "new_files_count": 1,
+      "percent_added": 0.0,
+      "percent_removed": 0.0,
+      "percent_moved": 0.0,
+      "percent_modified": 100.0,
+      "percent_unmodified": 0.0
+    },
+    "deltas": [
+      {
+        "status": "modified",
+        "factors": [],
+        "score": 20,
+        "new": {
+          "path": "coalib/__init__.py",
+          "type": "file",
+          "name": "__init__.py",
+          "size": 587,
+          "sha1": "8fc64c86979if8cec0758cfe0fe92d85b219ac49",
+          "fingerprint": "",
+          "original_path": "coalib/__init__.py",
+          "licenses": [],
+          "copyrights": []
+        },
+        "old": {
+          "path": "coalib/__init__.py",
+          "type": "file",
+          "name": "__init__.py",
+          "size": 587,
+          "sha1": "8fc64c86979bf8cec0758cfe0fe92d85b219ac49",
+          "fingerprint": "",
+          "original_path": "coalib/__init__.py",
+          "licenses": [],
+          "copyrights": []
+        }
+      }
+    ]
+  }
+  

--- a/tests/data/deltacode/scancode_options_new.json
+++ b/tests/data/deltacode/scancode_options_new.json
@@ -1,0 +1,38 @@
+{
+    "headers": [
+      {
+        "tool_name": "scancode-toolkit",
+        "tool_version": "3.0.2.post1029.8efa043b4",
+        "options": {
+          "input": [
+            "/home/arnav-mandal1234/Downloads/coala-0.10.0/coalib/"
+          ],
+          "--fingerprint": true,
+          "--info": true,
+          "--json-pp": "o.json"
+        },
+        "notice": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.",
+        "start_timestamp": "2019-08-17T193247.327863",
+        "end_timestamp": "2019-08-17T193249.994771",
+        "message": null,
+        "errors": [],
+        "extra_data": {
+          "files_count": 1
+        }
+      }
+    ],
+    "files": [
+        {
+            "path": "coalib/__init__.py",
+            "type": "file",
+            "name": "__init__.py",
+            "size": 587,
+            "date": "2017-02-05",
+            "sha1": "8fc64c86979if8cec0758cfe0fe92d85b219ac49",
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          }
+    ]
+}

--- a/tests/data/deltacode/scancode_options_old.json
+++ b/tests/data/deltacode/scancode_options_old.json
@@ -1,0 +1,38 @@
+{
+    "headers": [
+      {
+        "tool_name": "scancode-toolkit",
+        "tool_version": "3.0.2.post1029.8efa043b4",
+        "options": {
+          "input": [
+            "/home/arnav-mandal1234/Downloads/coala-0.10.0/coalib/"
+          ],
+          "--fingerprint": true,
+          "--info": true,
+          "--json-pp": "o.json"
+        },
+        "notice": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.",
+        "start_timestamp": "2019-08-17T193247.327863",
+        "end_timestamp": "2019-08-17T193249.994771",
+        "message": null,
+        "errors": [],
+        "extra_data": {
+          "files_count": 1
+        }
+      }
+    ],
+    "files": [
+        {
+            "path": "coalib/__init__.py",
+            "type": "file",
+            "name": "__init__.py",
+            "size": 587,
+            "date": "2017-02-05",
+            "sha1": "8fc64c86979bf8cec0758cfe0fe92d85b219ac49",
+            "files_count": 0,
+            "dirs_count": 0,
+            "size_count": 0,
+            "scan_errors": []
+          }
+    ]
+}

--- a/tests/data/deltacode/sugar-expected.json
+++ b/tests/data/deltacode/sugar-expected.json
@@ -1,5 +1,27 @@
 {
   "deltacode_notice": "Generated with DeltaCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nDeltaCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nDeltaCode is a free software codebase-comparison tool from nexB Inc. and others.\nVisit https://github.com/nexB/deltacode/ for support and download.",
+  "new_scan_options": {
+    "input": [
+      "/home/arnav-mandal1234/Desktop/sugar-0.114/src/"
+    ],
+    "--fingerprint": true,
+    "--info": true,
+    "--json-pp": "o.json"
+  },
+  "old_scan_options": {
+    "input": [
+      "/home/arnav-mandal1234/Desktop/sugar-0.108.0/src/"
+    ],
+    "--fingerprint": true,
+    "--info": true,
+    "--json-pp": "o.json"
+  },
+  "deltacode_options": {
+    "--new": "tests/data/deltacode/sugar-0.114-new.json",
+    "--old": "tests/data/deltacode/sugar-0.108.0-old.json",
+    "--all-delta-types": true
+  },
+  "deltacode_version": "1.0.1.dev112+gde3c583.d20210613",
   "deltacode_errors": [],
   "deltas_count": 136,
   "delta_stats": {

--- a/tests/test_deltacode.py
+++ b/tests/test_deltacode.py
@@ -1463,3 +1463,11 @@ class TestDeltacode(FileBasedTesting):
         args = ['--new', new_file, '--old', old_file, '--json-file', result_file, '--all-delta-types']
         test_utils.run_scan_click(args)
         test_utils.check_json_scan(self.get_test_loc('deltacode/sugar-coala-expected.json'), result_file, regen=False)
+        
+    def test_scancode_options(self):
+        old_file = self.get_test_loc('deltacode/scancode_options_old.json')
+        new_file = self.get_test_loc('deltacode/scancode_options_new.json')
+        result_file = self.get_temp_file('json')
+        args = ['--new', new_file, '--old', old_file, '--json-file', result_file, '--all-delta-types']
+        test_utils.run_scan_click(args)
+        test_utils.check_json_scan(self.get_test_loc('deltacode/scancode_options_expected.json'), result_file, regen=False)


### PR DESCRIPTION
This PR is meant to provide details about the `scancode_header_options` present in the scancode scans.
Additionally we will have these `options` present now in the headers.
`

    "deltacode_notice": "Generated with DeltaCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nDeltaCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nDeltaCode is a free software codebase-comparison tool from nexB Inc. and others.\nVisit https://github.com/nexB/deltacode/ for support and download.",
    "new_scan_options": {
      "input": [
        "/home/coala-0.10.0/coalib/"
      ],

      "--fingerprint": true,
      "--info": true,
      "--json-pp": "o.json"
    },

    "old_scan_options": {
      "input": [
        "/home/coala-0.10.0/coalib/"
      ],
      "--fingerprint": true,
      "--info": true,

      "--json-pp": "o.json"
    },
`
Signed-off-by: Pratik Dey <pratikrocks.dey11@gmail.com>