### PR TITLE
Replace freenode references with libera chat

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -48,9 +48,9 @@ For other questions, discussions, and chats, we have:
   Gitter also has an IRC bridge at https://irc.gitter.im/
   This is the main place where we chat and meet.
 
-- an official #aboutcode IRC channel on freenode (server chat.freenode.net)
+- an official #aboutcode IRC channel on liberachat (server web.libera.chat)
   for DeltaCode and other related tools. You can use your
-  favorite IRC client or use the web chat at https://webchat.freenode.net/ .
+  favorite IRC client or use the web chat at https://web.libera.chat/?#aboutcode .
   This is a busy place with a lot of CI and commit notifications that makes
   actual chat sometimes difficult!
 

--- a/README.rst
+++ b/README.rst
@@ -80,11 +80,11 @@ For other questions, discussions, and chats, we have:
 - an official Gitter channel at https://gitter.im/aboutcode-org/discuss
   Gitter also has an IRC bridge at https://irc.gitter.im/
 
-- an official #aboutcode IRC channel on freenode (server chat.freenode.net)
+- an official #aboutcode IRC channel on liberachat (server web.libera.chat)
   for DeltaCode and other related tools. Note that this receives
   notifications from repos so it can be a tad noisy. You can use your
   favorite IRC client or use the web chat at
-  https://webchat.freenode.net/
+  https://web.libera.chat/?#aboutcode .
 
 
 Source code


### PR DESCRIPTION
**Reference Issues/PRs**

Fixes [Replace references to freenode #92](https://github.com/nexB/aboutcode/issues/92)

**What does this implement/fix? Explain your changes.**
There were some outdated freenode references present in CONTRIBUTING.rst so replaced this address with the official IRC channel i.e Gitter and liberachat

**Any other comments?**
Thank You!